### PR TITLE
Set client open orders address on margin account callback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+- market: Add helper functions for finding a market given parameters. ([#9](https://github.com/zetamarkets/sdk/pull/9))
+- client: Update client open orders address on callback for scenario where open orders address is initialized outside of the sdk.
+
 ## [0.8.0] 2021-12-06
 
 - insurance-client: Insurance fund functionality, whitelist checks, deposit & withdrawal. ([#9](https://github.com/zetamarkets/sdk/pull/9))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.8.1] 2021-12-07
+
 - market: Add helper functions for finding a market given parameters. ([#9](https://github.com/zetamarkets/sdk/pull/9))
-- client: Update client open orders address on callback for scenario where open orders address is initialized outside of the sdk.
+- client: Update client open orders address on callback for scenario where open orders address is initialized outside of the sdk. ([#20](https://github.com/zetamarkets/sdk/pull/20))
 
 ## [0.8.0] 2021-12-06
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Handles the scenario where an open orders account is created outside of the SDK i.e. CPI.