### PR TITLE
Autogenerated changes due to U64 liquidation size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
-- program: Change liquidate() size argument from u32 to u64.
+- program: Change liquidate() size argument in program from u32 to u64. ([#103](https://github.com/zetamarkets/sdk/pull/103))
 - program: Mark greek accounts as immutable in certain instructions.
 
 ## [0.13.0] 2022-03-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+- program: Change liquidate() size argument from u32 to u64.
 - program: Mark greek accounts as immutable in certain instructions.
 
 ## [0.13.0] 2022-03-13

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -2281,7 +2281,7 @@
       "args": [
         {
           "name": "size",
-          "type": "u32"
+          "type": "u64"
         }
       ]
     },

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -2281,7 +2281,7 @@ export type Zeta = {
       "args": [
         {
           "name": "size",
-          "type": "u32"
+          "type": "u64"
         }
       ]
     },
@@ -6736,7 +6736,7 @@ export const IDL: Zeta = {
       "args": [
         {
           "name": "size",
-          "type": "u32"
+          "type": "u64"
         }
       ]
     },


### PR DESCRIPTION
(Auto-generated from changes in https://github.com/zetamarkets/zeta-options/pull/415)

Liquidate size has been bumped to u64 in the zeta-options program, and the changes here are autogenerated based on that. Note that the typescript 'number' type is actually limited to ~u53 in practice 😊 