### PR TITLE
Liquidation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Version changes are pinned to SDK releases.
 - client: Add new instructions ReplaceByClientOrderId, CancelAllOrdersNoError and CancelMultipleOrdersNoError. ([#114](https://github.com/zetamarkets/sdk/pull/114))
 
 
+- events: Add new event LiquidationEvent. ([#118](https://github.com/zetamarkets/sdk/pull/118))
 - events: Add isTaker boolean to PlaceOrderEvent. ([#116](https://github.com/zetamarkets/sdk/pull/116))
 
 ## [0.14.1]

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -5251,7 +5251,4 @@
       "msg": "Exceeded max spread account contracts"
     }
   ],
-  "metadata": {
-    "address": "BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7"
-  }
 }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -4672,6 +4672,31 @@
           "index": false
         }
       ]
+    },
+    {
+      "name": "LiquidationEvent",
+      "fields": [
+        {
+          "name": "liquidatorReward",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "insuranceReward",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "size",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "remainingBalance",
+          "type": "u64",
+          "index": false
+        }
+      ]
     }
   ],
   "errors": [

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -5250,5 +5250,5 @@
       "name": "ExceededMaxSpreadAccountContracts",
       "msg": "Exceeded max spread account contracts"
     }
-  ],
+  ]
 }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -4687,12 +4687,32 @@
           "index": false
         },
         {
+          "name": "costOfTrades",
+          "type": "u64",
+          "index": false
+        },
+        {
           "name": "size",
           "type": "u64",
           "index": false
         },
         {
-          "name": "remainingBalance",
+          "name": "remainingLiquidateeBalance",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "remainingLiquidatorBalance",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "markPrice",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "underlyingPrice",
           "type": "u64",
           "index": false
         }

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -252,6 +252,10 @@ export interface PositionMovementEvent {
 export interface LiquidationEvent {
   liquidatorReward: anchor.BN;
   insuranceReward: anchor.BN;
+  costOfTrades: anchor.BN;
   size: anchor.BN;
-  remainingBalance: anchor.BN;
+  remainingLiquidateeBalance: anchor.BN;
+  remainingLiquidatorBalance: anchor.BN;
+  markPrice: anchor.BN;
+  underlyingPrice: anchor.BN;
 }

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -248,3 +248,10 @@ export interface PositionMovementEvent {
   spreadAccountBalance: anchor.BN;
   movementFees: anchor.BN;
 }
+
+export interface LiquidationEvent {
+  liquidatorReward: anchor.BN;
+  insuranceReward: anchor.BN;
+  size: anchor.BN;
+  remainingBalance: anchor.BN;
+}

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -4672,6 +4672,31 @@ export type Zeta = {
           "index": false
         }
       ]
+    },
+    {
+      "name": "LiquidationEvent",
+      "fields": [
+        {
+          "name": "liquidatorReward",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "insuranceReward",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "size",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "remainingBalance",
+          "type": "u64",
+          "index": false
+        }
+      ]
     }
   ],
   "errors": [
@@ -9879,6 +9904,31 @@ export const IDL: Zeta = {
         {
           "name": "isTaker",
           "type": "bool",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "LiquidationEvent",
+      "fields": [
+        {
+          "name": "liquidatorReward",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "insuranceReward",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "size",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "remainingBalance",
+          "type": "u64",
           "index": false
         }
       ]

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -4687,12 +4687,32 @@ export type Zeta = {
           "index": false
         },
         {
+          "name": "costOfTrades",
+          "type": "u64",
+          "index": false
+        },
+        {
           "name": "size",
           "type": "u64",
           "index": false
         },
         {
-          "name": "remainingBalance",
+          "name": "remainingLiquidateeBalance",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "remainingLiquidatorBalance",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "markPrice",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "underlyingPrice",
           "type": "u64",
           "index": false
         }
@@ -9922,12 +9942,32 @@ export const IDL: Zeta = {
           "index": false
         },
         {
+          "name": "costOfTrades",
+          "type": "u64",
+          "index": false
+        },
+        {
           "name": "size",
           "type": "u64",
           "index": false
         },
         {
-          "name": "remainingBalance",
+          "name": "remainingLiquidateeBalance",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "remainingLiquidatorBalance",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "markPrice",
+          "type": "u64",
+          "index": false
+        },
+        {
+          "name": "underlyingPrice",
           "type": "u64",
           "index": false
         }


### PR DESCRIPTION
Goes hand-in-hand with the DEX PR https://github.com/zetamarkets/zeta-options/pull/429. From that description:

_Add new event LiquidationEvent, that gets emitted on every successful liquidate() instruction. We will use the indexers to enrich any liquidate() instructions with this additional information once it is in mainnet, as well as it just providing extra handy info for SDK users._