### PR TITLE
Add asset to marginaccount and spreadaccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+- program: Add Asset to MarginAccount and SpreadAccount. ([#126](https://github.com/zetamarkets/sdk/pull/126))
+
 ## [0.14.2]
 
 - general: Specify buffer-layout version in package.json. ([#119](https://github.com/zetamarkets/sdk/pull/119))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
-- program: Add Asset to MarginAccount and SpreadAccount. ([#126](https://github.com/zetamarkets/sdk/pull/126))
+- program: Add Asset to MarginAccount, SpreadAccount and ZetaGroup. ([#126](https://github.com/zetamarkets/sdk/pull/126))
 
 ## [0.14.2]
 

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -34,3 +34,9 @@ export function assetToOracleFeed(asset: Asset) {
   let name = assetToName(asset);
   return `${name}/USD`;
 }
+
+export function toProgramAsset(asset: Asset) {
+  if (asset == Asset.SOL) return { sol: {} };
+  if (asset == Asset.BTC) return { sol: {} };
+  throw Error("Invalid asset");
+}

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -4,6 +4,8 @@ import { PublicKey } from "@solana/web3.js";
 export enum Asset {
   SOL = 0,
   BTC = 1,
+  ETH = 2,
+  UNDEFINED = 255,
 }
 
 import * as constants from "./constants";
@@ -11,18 +13,21 @@ import * as constants from "./constants";
 export function assetToName(asset: Asset) {
   if (asset == Asset.SOL) return "SOL";
   if (asset == Asset.BTC) return "BTC";
+  if (asset == Asset.ETH) return "ETH";
   throw Error("Invalid asset");
 }
 
 export function nameToAsset(name: string) {
   if (name == "SOL") return Asset.SOL;
   if (name == "BTC") return Asset.BTC;
+  if (name == "ETH") return Asset.ETH;
   throw Error("Invalid asset");
 }
 
 export function oracleFeedToAsset(feed: string) {
   if (feed == "SOL/USD") return Asset.SOL;
   if (feed == "BTC/USD") return Asset.BTC;
+  if (feed == "ETH/USD") return Asset.ETH;
   throw Error("Invalid asset");
 }
 
@@ -37,12 +42,14 @@ export function assetToOracleFeed(asset: Asset) {
 
 export function toProgramAsset(asset: Asset) {
   if (asset == Asset.SOL) return { sol: {} };
-  if (asset == Asset.BTC) return { sol: {} };
+  if (asset == Asset.BTC) return { btc: {} };
+  if (asset == Asset.ETH) return { eth: {} };
   throw Error("Invalid asset");
 }
 
 export function fromProgramAsset(asset: any) {
   if (asset.sol != undefined) return Asset.SOL;
   if (asset.btc != undefined) return Asset.BTC;
+  if (asset.eth != undefined) return Asset.ETH;
   throw Error("Invalid asset");
 }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -40,3 +40,9 @@ export function toProgramAsset(asset: Asset) {
   if (asset == Asset.BTC) return { sol: {} };
   throw Error("Invalid asset");
 }
+
+export function fromProgramAsset(asset: any) {
+  if (asset.sol != undefined) return Asset.SOL;
+  if (asset.btc != undefined) return Asset.BTC;
+  throw Error("Invalid asset");
+}

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,0 +1,36 @@
+import { PublicKey } from "@solana/web3.js";
+
+// Ordered in underlying sequence number.
+export enum Asset {
+  SOL = 0,
+  BTC = 1,
+}
+
+import * as constants from "./constants";
+
+export function assetToName(asset: Asset) {
+  if (asset == Asset.SOL) return "SOL";
+  if (asset == Asset.BTC) return "BTC";
+  throw Error("Invalid asset");
+}
+
+export function nameToAsset(name: string) {
+  if (name == "SOL") return Asset.SOL;
+  if (name == "BTC") return Asset.BTC;
+  throw Error("Invalid asset");
+}
+
+export function oracleFeedToAsset(feed: string) {
+  if (feed == "SOL/USD") return Asset.SOL;
+  if (feed == "BTC/USD") return Asset.BTC;
+  throw Error("Invalid asset");
+}
+
+export function getAssetMint(asset: Asset): PublicKey {
+  return constants.MINTS[asset];
+}
+
+export function assetToOracleFeed(asset: Asset) {
+  let name = assetToName(asset);
+  return `${name}/USD`;
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -494,7 +494,6 @@ export class Client {
       console.log("User has no margin account. Creating margin account...");
       tx.add(
         initializeMarginAccountIx(
-          assets.Asset.SOL, // TODO change with full multiunderlying PR
           Exchange.zetaGroupAddress,
           this._marginAccountAddress,
           this.publicKey
@@ -772,7 +771,6 @@ export class Client {
       console.log("User has no spread account. Creating spread account...");
       tx.add(
         initializeSpreadAccountIx(
-          assets.Asset.SOL, // TODO change with full multiunderlying PR
           Exchange.zetaGroupAddress,
           this.spreadAccountAddress,
           this.publicKey
@@ -1620,7 +1618,6 @@ export class Client {
       console.log("User has no spread account. Creating spread account...");
       tx.add(
         initializeSpreadAccountIx(
-          assets.Asset.SOL, // TODO change with full multiunderlying PR
           Exchange.zetaGroupAddress,
           this.spreadAccountAddress,
           this.publicKey

--- a/src/client.ts
+++ b/src/client.ts
@@ -64,6 +64,8 @@ import {
 
 import { EventType } from "./events";
 
+import * as assets from "./assets";
+
 export class Client {
   /**
    * Returns the user wallet public key.
@@ -492,6 +494,7 @@ export class Client {
       console.log("User has no margin account. Creating margin account...");
       tx.add(
         initializeMarginAccountIx(
+          assets.Asset.SOL, // TODO change with full multiunderlying PR
           Exchange.zetaGroupAddress,
           this._marginAccountAddress,
           this.publicKey
@@ -769,6 +772,7 @@ export class Client {
       console.log("User has no spread account. Creating spread account...");
       tx.add(
         initializeSpreadAccountIx(
+          assets.Asset.SOL, // TODO change with full multiunderlying PR
           Exchange.zetaGroupAddress,
           this.spreadAccountAddress,
           this.publicKey
@@ -1616,6 +1620,7 @@ export class Client {
       console.log("User has no spread account. Creating spread account...");
       tx.add(
         initializeSpreadAccountIx(
+          assets.Asset.SOL, // TODO change with full multiunderlying PR
           Exchange.zetaGroupAddress,
           this.spreadAccountAddress,
           this.publicKey

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,8 @@ export const MAX_GREEK_UPDATES_PER_TX = 20;
 export const MAX_SETTLEMENT_ACCOUNTS = 20;
 export const MAX_REBALANCE_ACCOUNTS = 20;
 export const MAX_SETTLE_ACCOUNTS = 5;
+export const MAX_ZETA_GROUPS = 20;
+export const MAX_MARGIN_AND_SPREAD_ACCOUNTS = 20;
 export const MARKET_INDEX_LIMIT = 18;
 // 3 accounts per set * 9 = 27 + 2 = 29 accounts.
 export const CLEAN_MARKET_LIMIT = 9;

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -152,7 +152,14 @@
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
     },
     {
       "name": "initializeSpreadAccount",
@@ -188,7 +195,14 @@
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
     },
     {
       "name": "closeMarginAccount",
@@ -3381,11 +3395,17 @@
             }
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                263
+                262
               ]
             }
           }
@@ -3458,11 +3478,17 @@
             "type": "i64"
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                388
+                387
               ]
             }
           }
@@ -4539,6 +4565,20 @@
           },
           {
             "name": "Ask"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Asset",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SOL"
+          },
+          {
+            "name": "BTC"
           }
         ]
       }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -92,42 +92,15 @@
     },
     {
       "name": "refreshZetaGroupAsset",
-      "accounts": [
-        {
-          "name": "zetaGroup",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
+      "accounts": [],
       "args": []
     },
     {
-      "name": "refreshMarginAccountAsset",
+      "name": "refreshAccountAsset",
       "accounts": [
         {
           "name": "zetaGroup",
           "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "marginAccount",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "refreshSpreadAccountAsset",
-      "accounts": [
-        {
-          "name": "zetaGroup",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "spreadAccount",
-          "isMut": true,
           "isSigner": false
         }
       ],

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -91,6 +91,59 @@
       ]
     },
     {
+      "name": "refreshZetaGroupAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "refreshMarginAccountAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "refreshSpreadAccountAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spreadAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "overrideExpiry",
       "accounts": [
         {
@@ -152,14 +205,7 @@
           "isSigner": false
         }
       ],
-      "args": [
-        {
-          "name": "asset",
-          "type": {
-            "defined": "Asset"
-          }
-        }
-      ]
+      "args": []
     },
     {
       "name": "initializeSpreadAccount",
@@ -195,14 +241,7 @@
           "isSigner": false
         }
       ],
-      "args": [
-        {
-          "name": "asset",
-          "type": {
-            "defined": "Asset"
-          }
-        }
-      ]
+      "args": []
     },
     {
       "name": "closeMarginAccount",
@@ -3306,11 +3345,17 @@
             "type": "u64"
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                1063
+                1062
               ]
             }
           }
@@ -5285,6 +5330,11 @@
       "code": 6106,
       "name": "OraclePriceIsInvalid",
       "msg": "Fetched oracle price is invalid"
+    },
+    {
+      "code": 6107,
+      "name": "InvalidUnderlyingMint",
+      "msg": "Provided underlying mint address is invalid"
     }
   ]
 }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -110,11 +110,6 @@
           "isSigner": false
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
           "name": "marginAccount",
           "isMut": true,
           "isSigner": false
@@ -129,11 +124,6 @@
           "name": "zetaGroup",
           "isMut": false,
           "isSigner": false
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
         },
         {
           "name": "spreadAccount",

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -4587,6 +4587,12 @@
           },
           {
             "name": "BTC"
+          },
+          {
+            "name": "ETH"
+          },
+          {
+            "name": "UNDEFINED"
           }
         ]
       }
@@ -5293,11 +5299,6 @@
       "code": 6106,
       "name": "OraclePriceIsInvalid",
       "msg": "Fetched oracle price is invalid"
-    },
-    {
-      "code": 6107,
-      "name": "InvalidUnderlyingMint",
-      "msg": "Provided underlying mint address is invalid"
     }
   ]
 }

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -883,12 +883,10 @@ export function refreshZetaGroupAssetIx(): TransactionInstruction {
 
 export function refreshMarginAccountAssetIx(
   marginAccount: PublicKey,
-  user: PublicKey
 ): TransactionInstruction {
   return Exchange.program.instruction.refreshMarginAccountAsset({
     accounts: {
       marginAccount: marginAccount,
-      authority: user,
       zetaGroup: Exchange.zetaGroupAddress,
     },
   });
@@ -896,12 +894,10 @@ export function refreshMarginAccountAssetIx(
 
 export function refreshSpreadAccountAssetIx(
   spreadAccount: PublicKey,
-  user: PublicKey
 ): TransactionInstruction {
   return Exchange.program.instruction.refreshSpreadAccountAsset({
     accounts: {
       spreadAccount: spreadAccount,
-      authority: user,
       zetaGroup: Exchange.zetaGroupAddress,
     },
   });

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -23,24 +23,20 @@ import { types } from ".";
 import * as assets from "./assets";
 
 export function initializeMarginAccountIx(
-  asset: assets.Asset,
   zetaGroup: PublicKey,
   marginAccount: PublicKey,
   user: PublicKey
 ): TransactionInstruction {
-  return Exchange.program.instruction.initializeMarginAccount(
-    assets.toProgramAsset(asset),
-    {
-      accounts: {
-        zetaGroup,
-        marginAccount,
-        authority: user,
-        payer: user,
-        zetaProgram: Exchange.programId,
-        systemProgram: SystemProgram.programId,
-      },
-    }
-  );
+  return Exchange.program.instruction.initializeMarginAccount({
+    accounts: {
+      zetaGroup,
+      marginAccount,
+      authority: user,
+      payer: user,
+      zetaProgram: Exchange.programId,
+      systemProgram: SystemProgram.programId,
+    },
+  });
 }
 
 export function closeMarginAccountIx(
@@ -879,6 +875,38 @@ export async function initializeZetaGroupIx(
   );
 }
 
+export function refreshZetaGroupAssetIx(): TransactionInstruction {
+  return Exchange.program.instruction.refreshZetaGroupAsset({
+    accounts: { zetaGroup: Exchange.zetaGroupAddress },
+  });
+}
+
+export function refreshMarginAccountAssetIx(
+  marginAccount: PublicKey,
+  user: PublicKey
+): TransactionInstruction {
+  return Exchange.program.instruction.refreshMarginAccountAsset({
+    accounts: {
+      marginAccount: marginAccount,
+      authority: user,
+      zetaGroup: Exchange.zetaGroupAddress,
+    },
+  });
+}
+
+export function refreshSpreadAccountAssetIx(
+  spreadAccount: PublicKey,
+  user: PublicKey
+): TransactionInstruction {
+  return Exchange.program.instruction.refreshSpreadAccountAsset({
+    accounts: {
+      spreadAccount: spreadAccount,
+      authority: user,
+      zetaGroup: Exchange.zetaGroupAddress,
+    },
+  });
+}
+
 export function rebalanceInsuranceVaultIx(
   remainingAccounts: any[]
 ): TransactionInstruction {
@@ -1487,24 +1515,20 @@ export function expireSeriesOverrideIx(
 }
 
 export function initializeSpreadAccountIx(
-  asset: assets.Asset,
   zetaGroup: PublicKey,
   spreadAccount: PublicKey,
   user: PublicKey
 ): TransactionInstruction {
-  return Exchange.program.instruction.initializeSpreadAccount(
-    assets.toProgramAsset(asset),
-    {
-      accounts: {
-        zetaGroup,
-        spreadAccount,
-        authority: user,
-        payer: user,
-        zetaProgram: Exchange.programId,
-        systemProgram: SystemProgram.programId,
-      },
-    }
-  );
+  return Exchange.program.instruction.initializeSpreadAccount({
+    accounts: {
+      zetaGroup,
+      spreadAccount,
+      authority: user,
+      payer: user,
+      zetaProgram: Exchange.programId,
+      systemProgram: SystemProgram.programId,
+    },
+  });
 }
 
 export function closeSpreadAccountIx(

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -875,34 +875,54 @@ export async function initializeZetaGroupIx(
   );
 }
 
-export function refreshZetaGroupAssetIx(): TransactionInstruction {
+export function refreshZetaGroupAssetTx(
+  zetaGroups: AccountMeta[]
+): Transaction[] {
+  let txs = [];
+  for (var i = 0; i < zetaGroups.length; i += constants.MAX_ZETA_GROUPS) {
+    let tx = new Transaction();
+    let slice = zetaGroups.slice(i, i + constants.MAX_ZETA_GROUPS);
+    tx.add(refreshZetaGroupAssetIx(slice));
+    txs.push(tx);
+  }
+  return txs;
+}
+
+export function refreshZetaGroupAssetIx(
+  zetaGroups: AccountMeta[]
+): TransactionInstruction {
   return Exchange.program.instruction.refreshZetaGroupAsset({
-    accounts: { zetaGroup: Exchange.zetaGroupAddress },
+    remainingAccounts: zetaGroups,
   });
 }
 
-export function refreshMarginAccountAssetIx(
-  marginAccount: PublicKey,
+export function refreshAccountAssetTx(
+  zetaGroup: PublicKey,
+  accounts: AccountMeta[]
+): Transaction[] {
+  let txs = [];
+  for (
+    var i = 0;
+    i < accounts.length;
+    i += constants.MAX_MARGIN_AND_SPREAD_ACCOUNTS
+  ) {
+    let tx = new Transaction();
+    let slice = accounts.slice(i, i + constants.MAX_MARGIN_AND_SPREAD_ACCOUNTS);
+    tx.add(refreshAccountAssetIx(zetaGroup, slice));
+    txs.push(tx);
+  }
+  return txs;
+}
+
+export function refreshAccountAssetIx(
+  zetaGroup: PublicKey,
+  accounts: AccountMeta[]
 ): TransactionInstruction {
-  return Exchange.program.instruction.refreshMarginAccountAsset({
-    accounts: {
-      marginAccount: marginAccount,
-      zetaGroup: Exchange.zetaGroupAddress,
-    },
+  return Exchange.program.instruction.refreshAccountAsset({
+    accounts: { zetaGroup: zetaGroup },
+    remainingAccounts: accounts,
   });
 }
-
-export function refreshSpreadAccountAssetIx(
-  spreadAccount: PublicKey,
-): TransactionInstruction {
-  return Exchange.program.instruction.refreshSpreadAccountAsset({
-    accounts: {
-      spreadAccount: spreadAccount,
-      zetaGroup: Exchange.zetaGroupAddress,
-    },
-  });
-}
-
 export function rebalanceInsuranceVaultIx(
   remainingAccounts: any[]
 ): TransactionInstruction {

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -19,13 +19,15 @@ import {
   toProgramMovementType,
 } from "./types";
 import * as constants from "./constants";
+import { types } from ".";
 
 export function initializeMarginAccountIx(
+  args: types.InitializeMarginAccountArgs,
   zetaGroup: PublicKey,
   marginAccount: PublicKey,
   user: PublicKey
 ): TransactionInstruction {
-  return Exchange.program.instruction.initializeMarginAccount({
+  return Exchange.program.instruction.initializeMarginAccount(args, {
     accounts: {
       zetaGroup,
       marginAccount,
@@ -1481,11 +1483,12 @@ export function expireSeriesOverrideIx(
 }
 
 export function initializeSpreadAccountIx(
+  args: types.InitializeSpreadAccountArgs,
   zetaGroup: PublicKey,
   spreadAccount: PublicKey,
   user: PublicKey
 ): TransactionInstruction {
-  return Exchange.program.instruction.initializeSpreadAccount({
+  return Exchange.program.instruction.initializeSpreadAccount(args, {
     accounts: {
       zetaGroup,
       spreadAccount,

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -20,23 +20,27 @@ import {
 } from "./types";
 import * as constants from "./constants";
 import { types } from ".";
+import * as assets from "./assets";
 
 export function initializeMarginAccountIx(
-  args: types.InitializeMarginAccountArgs,
+  asset: assets.Asset,
   zetaGroup: PublicKey,
   marginAccount: PublicKey,
   user: PublicKey
 ): TransactionInstruction {
-  return Exchange.program.instruction.initializeMarginAccount(args, {
-    accounts: {
-      zetaGroup,
-      marginAccount,
-      authority: user,
-      payer: user,
-      zetaProgram: Exchange.programId,
-      systemProgram: SystemProgram.programId,
-    },
-  });
+  return Exchange.program.instruction.initializeMarginAccount(
+    assets.toProgramAsset(asset),
+    {
+      accounts: {
+        zetaGroup,
+        marginAccount,
+        authority: user,
+        payer: user,
+        zetaProgram: Exchange.programId,
+        systemProgram: SystemProgram.programId,
+      },
+    }
+  );
 }
 
 export function closeMarginAccountIx(
@@ -1483,21 +1487,24 @@ export function expireSeriesOverrideIx(
 }
 
 export function initializeSpreadAccountIx(
-  args: types.InitializeSpreadAccountArgs,
+  asset: assets.Asset,
   zetaGroup: PublicKey,
   spreadAccount: PublicKey,
   user: PublicKey
 ): TransactionInstruction {
-  return Exchange.program.instruction.initializeSpreadAccount(args, {
-    accounts: {
-      zetaGroup,
-      spreadAccount,
-      authority: user,
-      payer: user,
-      zetaProgram: Exchange.programId,
-      systemProgram: SystemProgram.programId,
-    },
-  });
+  return Exchange.program.instruction.initializeSpreadAccount(
+    assets.toProgramAsset(asset),
+    {
+      accounts: {
+        zetaGroup,
+        spreadAccount,
+        authority: user,
+        payer: user,
+        zetaProgram: Exchange.programId,
+        systemProgram: SystemProgram.programId,
+      },
+    }
+  );
 }
 
 export function closeSpreadAccountIx(

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -96,6 +96,7 @@ export interface ZetaGroup {
   expirySeries: Array<ExpirySeries>;
   expirySeriesPadding: Array<ExpirySeries>;
   totalInsuranceVaultDeposits: anchor.BN;
+  asset: any;
   padding: Array<number>;
 }
 

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -146,7 +146,7 @@ export interface MarginAccount {
   productLedgers: Array<ProductLedger>;
   productLedgersPadding: Array<ProductLedger>;
   rebalanceAmount: anchor.BN;
-  asset: number;
+  asset: any;
   padding: Array<number>;
 }
 
@@ -157,7 +157,7 @@ export interface SpreadAccount {
   seriesExpiry: Array<anchor.BN>;
   positions: Array<Position>;
   positionsPadding: Array<Position>;
-  asset: number;
+  asset: any;
   padding: Array<number>;
 }
 

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -146,6 +146,7 @@ export interface MarginAccount {
   productLedgers: Array<ProductLedger>;
   productLedgersPadding: Array<ProductLedger>;
   rebalanceAmount: anchor.BN;
+  asset: number;
   padding: Array<number>;
 }
 
@@ -156,6 +157,7 @@ export interface SpreadAccount {
   seriesExpiry: Array<anchor.BN>;
   positions: Array<Position>;
   positionsPadding: Array<Position>;
+  asset: number;
   padding: Array<number>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import * as anchor from "@project-serum/anchor";
 import { BN } from "@project-serum/anchor";
 import { PublicKey, Transaction } from "@solana/web3.js";
+import { Asset } from "./assets";
 
 /**
  * Wallet interface for objects that can be used to sign provider transactions.
@@ -161,6 +162,14 @@ export interface CancelArgs {
   market: PublicKey;
   orderId: anchor.BN;
   cancelSide: Side;
+}
+
+export interface InitializeMarginAccountArgs {
+  asset: Asset;
+}
+
+export interface InitializeSpreadAccountArgs {
+  asset: Asset;
 }
 
 export interface MarginParams {

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,14 +164,6 @@ export interface CancelArgs {
   cancelSide: Side;
 }
 
-export interface InitializeMarginAccountArgs {
-  asset: Asset;
-}
-
-export interface InitializeSpreadAccountArgs {
-  asset: Asset;
-}
-
 export interface MarginParams {
   futureMarginInitial: number;
   futureMarginMaintenance: number;

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -92,42 +92,15 @@ export type Zeta = {
     },
     {
       "name": "refreshZetaGroupAsset",
-      "accounts": [
-        {
-          "name": "zetaGroup",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
+      "accounts": [],
       "args": []
     },
     {
-      "name": "refreshMarginAccountAsset",
+      "name": "refreshAccountAsset",
       "accounts": [
         {
           "name": "zetaGroup",
           "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "marginAccount",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "refreshSpreadAccountAsset",
-      "accounts": [
-        {
-          "name": "zetaGroup",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "spreadAccount",
-          "isMut": true,
           "isSigner": false
         }
       ],
@@ -5423,42 +5396,15 @@ export const IDL: Zeta = {
     },
     {
       "name": "refreshZetaGroupAsset",
-      "accounts": [
-        {
-          "name": "zetaGroup",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
+      "accounts": [],
       "args": []
     },
     {
-      "name": "refreshMarginAccountAsset",
+      "name": "refreshAccountAsset",
       "accounts": [
         {
           "name": "zetaGroup",
           "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "marginAccount",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "refreshSpreadAccountAsset",
-      "accounts": [
-        {
-          "name": "zetaGroup",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "spreadAccount",
-          "isMut": true,
           "isSigner": false
         }
       ],

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -152,7 +152,14 @@ export type Zeta = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
     },
     {
       "name": "initializeSpreadAccount",
@@ -188,7 +195,14 @@ export type Zeta = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
     },
     {
       "name": "closeMarginAccount",
@@ -3381,11 +3395,17 @@ export type Zeta = {
             }
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                263
+                262
               ]
             }
           }
@@ -3458,11 +3478,17 @@ export type Zeta = {
             "type": "i64"
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                388
+                387
               ]
             }
           }
@@ -4539,6 +4565,20 @@ export type Zeta = {
           },
           {
             "name": "Ask"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Asset",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SOL"
+          },
+          {
+            "name": "BTC"
           }
         ]
       }
@@ -5403,7 +5443,14 @@ export const IDL: Zeta = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
     },
     {
       "name": "initializeSpreadAccount",
@@ -5439,7 +5486,14 @@ export const IDL: Zeta = {
           "isSigner": false
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
     },
     {
       "name": "closeMarginAccount",
@@ -8632,11 +8686,17 @@ export const IDL: Zeta = {
             }
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                263
+                262
               ]
             }
           }
@@ -8709,11 +8769,17 @@ export const IDL: Zeta = {
             "type": "i64"
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                388
+                387
               ]
             }
           }
@@ -9790,6 +9856,20 @@ export const IDL: Zeta = {
           },
           {
             "name": "Ask"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Asset",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "SOL"
+          },
+          {
+            "name": "BTC"
           }
         ]
       }

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -4587,6 +4587,12 @@ export type Zeta = {
           },
           {
             "name": "BTC"
+          },
+          {
+            "name": "ETH"
+          },
+          {
+            "name": "UNDEFINED"
           }
         ]
       }
@@ -5293,11 +5299,6 @@ export type Zeta = {
       "code": 6106,
       "name": "OraclePriceIsInvalid",
       "msg": "Fetched oracle price is invalid"
-    },
-    {
-      "code": 6107,
-      "name": "InvalidUnderlyingMint",
-      "msg": "Provided underlying mint address is invalid"
     }
   ]
 };
@@ -9891,6 +9892,12 @@ export const IDL: Zeta = {
           },
           {
             "name": "BTC"
+          },
+          {
+            "name": "ETH"
+          },
+          {
+            "name": "UNDEFINED"
           }
         ]
       }
@@ -10597,11 +10604,6 @@ export const IDL: Zeta = {
       "code": 6106,
       "name": "OraclePriceIsInvalid",
       "msg": "Fetched oracle price is invalid"
-    },
-    {
-      "code": 6107,
-      "name": "InvalidUnderlyingMint",
-      "msg": "Provided underlying mint address is invalid"
     }
   ]
 };

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -110,11 +110,6 @@ export type Zeta = {
           "isSigner": false
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
           "name": "marginAccount",
           "isMut": true,
           "isSigner": false
@@ -129,11 +124,6 @@ export type Zeta = {
           "name": "zetaGroup",
           "isMut": false,
           "isSigner": false
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
         },
         {
           "name": "spreadAccount",
@@ -5451,11 +5441,6 @@ export const IDL: Zeta = {
           "isSigner": false
         },
         {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
           "name": "marginAccount",
           "isMut": true,
           "isSigner": false
@@ -5470,11 +5455,6 @@ export const IDL: Zeta = {
           "name": "zetaGroup",
           "isMut": false,
           "isSigner": false
-        },
-        {
-          "name": "authority",
-          "isMut": false,
-          "isSigner": true
         },
         {
           "name": "spreadAccount",

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -91,6 +91,59 @@ export type Zeta = {
       ]
     },
     {
+      "name": "refreshZetaGroupAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "refreshMarginAccountAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "refreshSpreadAccountAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spreadAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "overrideExpiry",
       "accounts": [
         {
@@ -152,14 +205,7 @@ export type Zeta = {
           "isSigner": false
         }
       ],
-      "args": [
-        {
-          "name": "asset",
-          "type": {
-            "defined": "Asset"
-          }
-        }
-      ]
+      "args": []
     },
     {
       "name": "initializeSpreadAccount",
@@ -195,14 +241,7 @@ export type Zeta = {
           "isSigner": false
         }
       ],
-      "args": [
-        {
-          "name": "asset",
-          "type": {
-            "defined": "Asset"
-          }
-        }
-      ]
+      "args": []
     },
     {
       "name": "closeMarginAccount",
@@ -3306,11 +3345,17 @@ export type Zeta = {
             "type": "u64"
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                1063
+                1062
               ]
             }
           }
@@ -5285,6 +5330,11 @@ export type Zeta = {
       "code": 6106,
       "name": "OraclePriceIsInvalid",
       "msg": "Fetched oracle price is invalid"
+    },
+    {
+      "code": 6107,
+      "name": "InvalidUnderlyingMint",
+      "msg": "Provided underlying mint address is invalid"
     }
   ]
 };
@@ -5382,6 +5432,59 @@ export const IDL: Zeta = {
       ]
     },
     {
+      "name": "refreshZetaGroupAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "refreshMarginAccountAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "refreshSpreadAccountAsset",
+      "accounts": [
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "spreadAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "overrideExpiry",
       "accounts": [
         {
@@ -5443,14 +5546,7 @@ export const IDL: Zeta = {
           "isSigner": false
         }
       ],
-      "args": [
-        {
-          "name": "asset",
-          "type": {
-            "defined": "Asset"
-          }
-        }
-      ]
+      "args": []
     },
     {
       "name": "initializeSpreadAccount",
@@ -5486,14 +5582,7 @@ export const IDL: Zeta = {
           "isSigner": false
         }
       ],
-      "args": [
-        {
-          "name": "asset",
-          "type": {
-            "defined": "Asset"
-          }
-        }
-      ]
+      "args": []
     },
     {
       "name": "closeMarginAccount",
@@ -8597,11 +8686,17 @@ export const IDL: Zeta = {
             "type": "u64"
           },
           {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                1063
+                1062
               ]
             }
           }
@@ -10576,6 +10671,11 @@ export const IDL: Zeta = {
       "code": 6106,
       "name": "OraclePriceIsInvalid",
       "msg": "Fetched oracle price is invalid"
+    },
+    {
+      "code": 6107,
+      "name": "InvalidUnderlyingMint",
+      "msg": "Provided underlying mint address is invalid"
     }
   ]
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1315,18 +1315,16 @@ export async function refreshZetaGroupAsset() {
 
 export async function refreshMarginAccountAsset(
   marginAccount: PublicKey,
-  user: PublicKey
 ) {
   let tx = new Transaction();
-  tx.add(refreshMarginAccountAssetIx(marginAccount, user));
+  tx.add(refreshMarginAccountAssetIx(marginAccount));
   await processTransaction(Exchange.provider, tx);
 }
 
 export async function refreshSpreadAccountAsset(
   spreadAccount: PublicKey,
-  user: PublicKey
 ) {
   let tx = new Transaction();
-  tx.add(refreshSpreadAccountAssetIx(spreadAccount, user));
+  tx.add(refreshSpreadAccountAssetIx(spreadAccount));
   await processTransaction(Exchange.provider, tx);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,9 @@ import {
   settlePositionsIx,
   settleSpreadPositionsIx,
   PositionMovementArg,
+  refreshZetaGroupAssetIx,
+  refreshMarginAccountAssetIx,
+  refreshSpreadAccountAssetIx,
 } from "./program-instructions";
 import { Decimal } from "./decimal";
 import { readBigInt64LE } from "./oracle-utils";
@@ -1302,4 +1305,28 @@ export function calculateMovementFees(
   let notionalValue = totalContracts * spotPrice;
   let fee = (notionalValue * feeBps) / constants.BPS_DENOMINATOR;
   return decimal ? fee : convertDecimalToNativeInteger(fee);
+}
+
+export async function refreshZetaGroupAsset() {
+  let tx = new Transaction();
+  tx.add(refreshZetaGroupAssetIx());
+  await processTransaction(Exchange.provider, tx);
+}
+
+export async function refreshMarginAccountAsset(
+  marginAccount: PublicKey,
+  user: PublicKey
+) {
+  let tx = new Transaction();
+  tx.add(refreshMarginAccountAssetIx(marginAccount, user));
+  await processTransaction(Exchange.provider, tx);
+}
+
+export async function refreshSpreadAccountAsset(
+  spreadAccount: PublicKey,
+  user: PublicKey
+) {
+  let tx = new Transaction();
+  tx.add(refreshSpreadAccountAssetIx(spreadAccount, user));
+  await processTransaction(Exchange.provider, tx);
 }


### PR DESCRIPTION
For multi-underlying support we want to know the asset of each margin and spread account. This adds it, and also forces any new accounts from here to pass in the asset.