### PR TITLE
Clock polling boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.16.5]
+
+- program: Add clock polling boolean to prevent stacking failed RPC requests. ([#141](https://github.com/zetamarkets/sdk/pull/141))
+
 ## [0.16.4]
 
 - program: Refactor fee collection methodology and add some associated instructions. ([#136](https://github.com/zetamarkets/sdk/pull/136))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -216,6 +216,8 @@ export class Exchange {
 
   private _programSubscriptionIds: number[] = [];
 
+  private _isClockPolling: boolean = false;
+
   // Stored by reference so we don't have to iterate through all subexchanges to grab them when updating orderbooks on timer
   private _markets: Market[] = [];
 
@@ -451,8 +453,10 @@ export class Exchange {
         try {
           if (
             this._clockTimestamp >
-            this._lastPollTimestamp + this._pollInterval
+              this._lastPollTimestamp + this._pollInterval &&
+            !this._isClockPolling
           ) {
+            this._isClockPolling = true;
             this._lastPollTimestamp = this._clockTimestamp;
             await Promise.all(
               this.getAllSubExchanges().map(async (subExchange) => {
@@ -463,6 +467,7 @@ export class Exchange {
         } catch (e) {
           console.log(`SubExchange polling failed. Error: ${e}`);
         }
+        this._isClockPolling = false;
       },
       this.provider.connection.commitment
     );


### PR DESCRIPTION
We have seen a few instances where prolonged RPC issues lead to a webserver outage. One problem that I've found is that we poll multiple accounts on a timer (`DEFAULT_EXCHANGE_POLL_INTERVAL`), but if one of them does not succeed then another timer interval is begun on top of that. For example:
![image](https://user-images.githubusercontent.com/103913117/183317038-720365a7-31d2-43a2-9524-f4fdbb85059f.png)
Here we see 1 `caught exception in orderbook poll function`, which has a similar boolean mechanism, and N `SubExchange polling failed`, which we're fixing here.  When the RPC issues are resolved we now have all of those N timers happening at once and the application grinds to a halt and needs a restart.