### PR TITLE
Bugfix client subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.16.11]
+
+- events: Improve event handling in client. ([#149](https://github.com/zetamarkets/sdk/pull/149))
+
 ## [0.16.10]
 
 - export calculateSpreadAccountMarginRequirement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
-## [0.16.11]
+## [0.16.12]
 
 - events: Improve event handling in client. ([#149](https://github.com/zetamarkets/sdk/pull/149))
+
+## [0.16.11]
+
+- skipped due to release issues
 
 ## [0.16.10]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -125,6 +125,7 @@ export class Client {
   ) {
     this._provider = new anchor.AnchorProvider(connection, wallet, opts);
     this._subClients = new Map();
+    this._marginAccountToAsset = new Map();
     this._referralAccount = null;
     this._referrerAccount = null;
     this._referrerAlias = null;
@@ -173,7 +174,6 @@ export class Client {
       client._whitelistTradingFeesAddress = whitelistTradingFeesAddress;
     } catch (e) {}
 
-    client._marginAccountToAsset = new Map();
     await Promise.all(
       Exchange.assets.map(async (asset) => {
         const subClient = await SubClient.load(
@@ -200,11 +200,14 @@ export class Client {
       client._tradeEventListener = Exchange.program.addEventListener(
         "TradeEvent",
         (event: TradeEvent, _slot) => {
-          let asset = client._marginAccountToAsset.get(
-            event.marginAccount.toString()
-          );
-          if (asset) {
-            callback(asset, EventType.TRADE, event);
+          if (
+            client._marginAccountToAsset.has(event.marginAccount.toString())
+          ) {
+            callback(
+              client._marginAccountToAsset.get(event.marginAccount.toString()),
+              EventType.TRADE,
+              event
+            );
           }
         }
       );
@@ -212,11 +215,14 @@ export class Client {
       client._orderCompleteEventListener = Exchange.program.addEventListener(
         "OrderCompleteEvent",
         (event: OrderCompleteEvent, _slot) => {
-          let asset = client._marginAccountToAsset.get(
-            event.marginAccount.toString()
-          );
-          if (asset) {
-            callback(asset, EventType.ORDERCOMPLETE, event);
+          if (
+            client._marginAccountToAsset.has(event.marginAccount.toString())
+          ) {
+            callback(
+              client._marginAccountToAsset.get(event.marginAccount.toString()),
+              EventType.ORDERCOMPLETE,
+              event
+            );
           }
         }
       );

--- a/src/events.ts
+++ b/src/events.ts
@@ -57,6 +57,8 @@ export function eventTypeToString(event: EventType) {
       return "GREEKS";
     case EventType.TRADE:
       return "TRADE";
+    case EventType.ORDERCOMPLETE:
+      return "ORDERCOMPLETE";
     case EventType.ORDERBOOK:
       return "ORDERBOOK";
     case EventType.ORACLE:

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -268,8 +268,8 @@ export interface PlaceOrderEvent {
 export interface TradeEvent {
   marginAccount: PublicKey;
   index: number;
-  size: anchor.BN;
   costOfTrades: anchor.BN;
+  size: anchor.BN;
   isBid: boolean;
   clientOrderId: anchor.BN;
   orderId: anchor.BN;

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -268,8 +268,8 @@ export interface PlaceOrderEvent {
 export interface TradeEvent {
   marginAccount: PublicKey;
   index: number;
-  costOfTrades: anchor.BN;
   size: anchor.BN;
+  costOfTrades: anchor.BN;
   isBid: boolean;
   clientOrderId: anchor.BN;
   orderId: anchor.BN;

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -127,16 +127,6 @@ export class SubClient {
   private _spreadAccountSubscriptionId: number = undefined;
 
   /**
-   * The listener for trade events.
-   */
-  private _tradeEventListener: any;
-
-  /**
-   * The listener for OrderComplete events.
-   */
-  private _orderCompleteEventListener: any;
-
-  /**
    * Last update timestamp.
    */
   private _lastUpdateTimestamp: number;
@@ -293,26 +283,6 @@ export class SubClient {
       subClient.updateSpreadPositions();
     } catch (e) {
       console.log("User does not have a spread account.");
-    }
-
-    if (callback !== undefined) {
-      subClient._tradeEventListener = Exchange.program.addEventListener(
-        "TradeEvent",
-        (event: TradeEvent, _slot) => {
-          if (event.marginAccount.equals(marginAccountAddress)) {
-            callback(asset, EventType.TRADE, event);
-          }
-        }
-      );
-
-      subClient._orderCompleteEventListener = Exchange.program.addEventListener(
-        "OrderCompleteEvent",
-        (event: OrderCompleteEvent, _slot) => {
-          if (event.marginAccount.equals(marginAccountAddress)) {
-            callback(asset, EventType.ORDERCOMPLETE, event);
-          }
-        }
-      );
     }
 
     return subClient;
@@ -1842,18 +1812,6 @@ export class SubClient {
         this._spreadAccountSubscriptionId
       );
       this._spreadAccountSubscriptionId = undefined;
-    }
-
-    if (this._tradeEventListener !== undefined) {
-      await Exchange.program.removeEventListener(this._tradeEventListener);
-      this._tradeEventListener = undefined;
-    }
-
-    if (this._orderCompleteEventListener !== undefined) {
-      await Exchange.program.removeEventListener(
-        this._orderCompleteEventListener
-      );
-      this._orderCompleteEventListener = undefined;
     }
   }
 }


### PR DESCRIPTION
If we use `callback` in `subclient.load()`, only the last loaded subclient's callback will actually fire on trade/ordercomplete events because of some Anchor shenanigans.

This PR moves that subscription logic out to the client to fix this issue for 1 client. I'll raise an Anchor PR too.