### PR TITLE
Improve cancelAllOrders and cancelMultipleOrders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.16.15]
+
+- client: cancelAllOrders() and cancelAllOrdersNoError() now bundle instructions of different assets into one transaction if possible. ([#155](https://github.com/zetamarkets/sdk/pull/155))
+
+### Breaking
+
+- client: cancelMultipleOrders() and cancelMultipleOrdersNoError() now require Asset in the CancelArgs[] function argument. ([#155](https://github.com/zetamarkets/sdk/pull/155))
+
 ## [0.16.14]
 
 - risk: Add available withdrawable balance for MMs. ([#151](https://github.com/zetamarkets/sdk/pull/151))

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.31.0",
-    "@zetamarkets/sdk": "file:../..",
+    "@zetamarkets/sdk": "^0.16.0",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.31.0",
-    "@zetamarkets/sdk": "^0.16.0",
+    "@zetamarkets/sdk": "file:../..",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.16",
+  "version": "0.16.15",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.15-beta.2",
+  "version": "0.16.16",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.14",
+  "version": "0.16.15-beta.2",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -463,7 +463,7 @@ export class Client {
     asset: Asset = undefined
   ): Promise<TransactionSignature[]> {
     if (asset) {
-      await this.getSubClient(asset).cancelAllOrders();
+      return await this.getSubClient(asset).cancelAllOrders();
     } else {
       let ixs = [];
       for (var subClient of this.getAllSubClients()) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -448,7 +448,7 @@ export class Client {
     fetch = true,
     force = false
   ) {
-    if (asset) {
+    if (asset != undefined) {
       await this.getSubClient(asset).updateState(fetch, force);
     } else {
       await Promise.all(
@@ -462,7 +462,7 @@ export class Client {
   public async cancelAllOrders(
     asset: Asset = undefined
   ): Promise<TransactionSignature[]> {
-    if (asset) {
+    if (asset != undefined) {
       return await this.getSubClient(asset).cancelAllOrders();
     } else {
       let ixs = [];
@@ -481,7 +481,7 @@ export class Client {
   public async cancelAllOrdersNoError(
     asset: Asset = undefined
   ): Promise<TransactionSignature[]> {
-    if (asset) {
+    if (asset != undefined) {
       return await this.getSubClient(asset).cancelAllOrdersNoError();
     } else {
       let allTxIds = [];

--- a/src/client.ts
+++ b/src/client.ts
@@ -463,20 +463,18 @@ export class Client {
     asset: Asset = undefined
   ): Promise<TransactionSignature[]> {
     if (asset) {
-      return await this.getSubClient(asset).cancelAllOrders();
+      await this.getSubClient(asset).cancelAllOrders();
     } else {
       let ixs = [];
       for (var subClient of this.getAllSubClients()) {
-        ixs.push(subClient.cancelAllOrdersIxs());
+        ixs = ixs.concat(subClient.cancelAllOrdersIxs());
       }
       let txs = utils.splitIxsIntoTx(ixs, constants.MAX_CANCELS_PER_TX);
-      let txIds: string[] = [];
-      await Promise.all(
+      return await Promise.all(
         txs.map(async (tx) => {
-          txIds.push(await utils.processTransaction(this.provider, tx));
+          return utils.processTransaction(this.provider, tx);
         })
       );
-      return txIds;
     }
   }
 

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -1448,10 +1448,7 @@ export class SubClient {
     return await utils.processTransaction(this._parent.provider, tx);
   }
 
-  /**
-   * Cancels all active user orders
-   */
-  public async cancelAllOrders(): Promise<TransactionSignature[]> {
+  public cancelAllOrdersIxs(): TransactionInstruction[] {
     // Can only fit 6 cancels worth of accounts per transaction.
     // on 4 separate markets
     // Compute is fine.
@@ -1469,8 +1466,17 @@ export class SubClient {
       );
       ixs.push(ix);
     }
+    return ixs;
+  }
 
-    let txs = utils.splitIxsIntoTx(ixs, constants.MAX_CANCELS_PER_TX);
+  /**
+   * Cancels all active user orders
+   */
+  public async cancelAllOrders(): Promise<TransactionSignature[]> {
+    let txs = utils.splitIxsIntoTx(
+      this.cancelAllOrdersIxs(),
+      constants.MAX_CANCELS_PER_TX
+    );
     let txIds: string[] = [];
     await Promise.all(
       txs.map(async (tx) => {

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -1472,18 +1472,17 @@ export class SubClient {
   /**
    * Cancels all active user orders
    */
-  public async cancelAllOrders(): Promise<TransactionSignature[]> {
+  public async cancelAllOrders(): Promise<void[]> {
     let txs = utils.splitIxsIntoTx(
       this.cancelAllOrdersIxs(),
       constants.MAX_CANCELS_PER_TX
     );
     let txIds: string[] = [];
-    await Promise.all(
+    return await Promise.all(
       txs.map(async (tx) => {
-        txIds.push(await utils.processTransaction(this._parent.provider, tx));
+        await utils.processTransaction(this._parent.provider, tx);
       })
     );
-    return txIds;
   }
 
   /**

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -1326,39 +1326,6 @@ export class SubClient {
   }
 
   /**
-   * Cancels multiple user orders by orderId
-   * @param cancelArguments list of cancelArgs objects which contains the arguments of cancel instructions
-   */
-  public async cancelMultipleOrdersNoError(
-    cancelArguments: types.CancelArgs[]
-  ): Promise<TransactionSignature[]> {
-    let ixs = [];
-    for (var i = 0; i < cancelArguments.length; i++) {
-      let marketIndex = this._subExchange.markets.getMarketIndex(
-        cancelArguments[i].market
-      );
-      let ix = instructions.cancelOrderNoErrorIx(
-        this.asset,
-        marketIndex,
-        this._parent.publicKey,
-        this._marginAccountAddress,
-        this._openOrdersAccounts[marketIndex],
-        cancelArguments[i].orderId,
-        cancelArguments[i].cancelSide
-      );
-      ixs.push(ix);
-    }
-    let txs = utils.splitIxsIntoTx(ixs, constants.MAX_CANCELS_PER_TX);
-    let txIds: string[] = [];
-    await Promise.all(
-      txs.map(async (tx) => {
-        txIds.push(await utils.processTransaction(this._parent.provider, tx));
-      })
-    );
-    return txIds;
-  }
-
-  /**
    * Calls force cancel on another user's orders
    * @param market  Market to cancel orders on
    * @param marginAccountToCancel Users to be force-cancelled's margin account

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -1382,10 +1382,11 @@ export class SubClient {
     return await utils.processTransaction(this._parent.provider, tx);
   }
 
+  /**
+   * Instruction builder for cancelAllOrders()
+   * Returns a list of instructions cancelling all of this subclient's orders
+   */
   public cancelAllOrdersIxs(): TransactionInstruction[] {
-    // Can only fit 6 cancels worth of accounts per transaction.
-    // on 4 separate markets
-    // Compute is fine.
     let ixs = [];
     for (var i = 0; i < this._orders.length; i++) {
       let order = this._orders[i];
@@ -1403,10 +1404,11 @@ export class SubClient {
     return ixs;
   }
 
+  /**
+   * Instruction builder for cancelAllOrdersNoError()
+   * Returns a list of instructions cancelling all of this subclient's orders
+   */
   public cancelAllOrdersNoErrorIxs(): TransactionInstruction[] {
-    // Can only fit 6 cancels worth of accounts per transaction.
-    // on 4 separate markets
-    // Compute is fine.
     let ixs = [];
     for (var i = 0; i < this._orders.length; i++) {
       let order = this._orders[i];
@@ -1428,6 +1430,9 @@ export class SubClient {
    * Cancels all active user orders
    */
   public async cancelAllOrders(): Promise<TransactionSignature[]> {
+    // Can only fit 6 cancels worth of accounts per transaction.
+    // on 4 separate markets
+    // Compute is fine.
     let txs = utils.splitIxsIntoTx(
       this.cancelAllOrdersIxs(),
       constants.MAX_CANCELS_PER_TX
@@ -1445,6 +1450,9 @@ export class SubClient {
    * Cancels all active user orders, but will not crash if some cancels fail
    */
   public async cancelAllOrdersNoError(): Promise<TransactionSignature[]> {
+    // Can only fit 6 cancels worth of accounts per transaction.
+    // on 4 separate markets
+    // Compute is fine.
     let txs = utils.splitIxsIntoTx(
       this.cancelAllOrdersNoErrorIxs(),
       constants.MAX_CANCELS_PER_TX

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,7 @@ export interface MarginAccountState {
 }
 
 export interface CancelArgs {
+  asset: Asset;
   market: PublicKey;
   orderId: anchor.BN;
   cancelSide: Side;


### PR DESCRIPTION
Slight logic change to `cancelAllOrders()` and `cancelMultipleOrders()` to make them bundle multiasset cancels into a single tx.
- `cancelAllOrders()` now works primarily inside `Client`, only grabbing `cancelAllOrdersIxs()` from each `SubClient`.
- `cancelMultipleOrders()` is now purely inside `Client`. _**It now requires `Asset` in each of the CancelArgs[] instead of the function arguments, which is breaking if someone uses `cancelMultipleOrders()`**_.
- Same thing for the `NoError` equivalents of each function.