### PR TITLE
Drop cancels_per_tx down from 4 to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.16.17]
+
+- constants: drop MAX_CANCELS_PER_TX down to 3 ([#156](https://github.com/zetamarkets/sdk/pull/156))
+
 ## [0.16.16]
 
 - client: cancelAllOrders() and cancelAllOrdersNoError() now bundle instructions of different assets into one transaction if possible. ([#155](https://github.com/zetamarkets/sdk/pull/155))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.16",
+  "version": "0.16.17",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,7 +15,7 @@ export const DEX_PID = {
 };
 
 export const MAX_SETTLE_AND_CLOSE_PER_TX = 4;
-export const MAX_CANCELS_PER_TX = 4;
+export const MAX_CANCELS_PER_TX = 3;
 export const MAX_GREEK_UPDATES_PER_TX = 20;
 export const MAX_SETTLEMENT_ACCOUNTS = 20;
 export const MAX_REBALANCE_ACCOUNTS = 18;


### PR DESCRIPTION
Now that we can cancel orders across assets in one transaction, we've run into an edge case: If you try to cancel 4 orders across all 3 assets, all on different market indexes, you run over the tx size limit by 18 bytes. 

Therefore we just drop cancels_per_tx from 4 -> 3