### PR TITLE
Add cancelAllMarketOrders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,9 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
-## [0.16.19]
-
-- client: add cancelAllMarketOrders(). ([#157](https://github.com/zetamarkets/sdk/pull/157))
-
 ## [0.16.18]
 
+- client: add cancelAllMarketOrders(). ([#157](https://github.com/zetamarkets/sdk/pull/157))
 - events: Add TradeEventV2. ([#153](https://github.com/zetamarkets/sdk/pull/153))
 - risk: Change initial margin calcs to use Max(shorts, longs) for futures instead of shorts + longs. ([#158](https://github.com/zetamarkets/sdk/pull/158))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.16.18]
+
+- client: add cancelAllMarketOrders(). ([#157](https://github.com/zetamarkets/sdk/pull/157))
+
 ## [0.16.17]
 
-- constants: drop MAX_CANCELS_PER_TX down to 3 ([#156](https://github.com/zetamarkets/sdk/pull/156))
+- constants: drop MAX_CANCELS_PER_TX down to 3. ([#156](https://github.com/zetamarkets/sdk/pull/156))
 
 ## [0.16.16]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.17",
+  "version": "0.16.18",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.19",
+  "version": "0.16.18",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -539,6 +539,25 @@ export class Client {
     );
   }
 
+  public async cancelAllMarketOrders(
+    asset: Asset,
+    market: types.MarketIdentifier
+  ): Promise<TransactionSignature> {
+    let tx = new Transaction();
+    let index = Exchange.getZetaGroupMarkets(asset).getMarketIndex(
+      this.marketIdentifierToPublicKey(asset, market)
+    );
+    let ix = instructions.cancelAllMarketOrdersIx(
+      asset,
+      index,
+      this.publicKey,
+      this.getSubClient(asset).marginAccountAddress,
+      this.getSubClient(asset).openOrdersAccounts[index]
+    );
+    tx.add(ix);
+    return await utils.processTransaction(this.provider, tx);
+  }
+
   public async cancelOrder(
     asset: Asset,
     market: types.MarketIdentifier,

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -2404,6 +2404,72 @@
       ]
     },
     {
+      "name": "cancelAllMarketOrders",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "cancelAccounts",
+          "accounts": [
+            {
+              "name": "zetaGroup",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "market",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "bids",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "asks",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "eventQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "cancelOrderHalted",
       "accounts": [
         {

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -547,6 +547,34 @@ export function cancelOrderNoErrorIx(
   );
 }
 
+export function cancelAllMarketOrdersIx(
+  asset: Asset,
+  marketIndex: number,
+  userKey: PublicKey,
+  marginAccount: PublicKey,
+  openOrders: PublicKey
+): TransactionInstruction {
+  let subExchange = Exchange.getSubExchange(asset);
+  let marketData = subExchange.markets.markets[marketIndex];
+  return Exchange.program.instruction.cancelAllMarketOrders({
+    accounts: {
+      authority: userKey,
+      cancelAccounts: {
+        zetaGroup: subExchange.zetaGroupAddress,
+        state: Exchange.stateAddress,
+        marginAccount,
+        dexProgram: constants.DEX_PID[Exchange.network],
+        serumAuthority: Exchange.serumAuthority,
+        openOrders,
+        market: marketData.address,
+        bids: marketData.serumMarket.decoded.bids,
+        asks: marketData.serumMarket.decoded.asks,
+        eventQueue: marketData.serumMarket.decoded.eventQueue,
+      },
+    },
+  });
+}
+
 export function cancelOrderByClientOrderIdIx(
   asset: Asset,
   marketIndex: number,

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -2404,6 +2404,72 @@ export type Zeta = {
       ]
     },
     {
+      "name": "cancelAllMarketOrders",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "cancelAccounts",
+          "accounts": [
+            {
+              "name": "zetaGroup",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "market",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "bids",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "asks",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "eventQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "cancelOrderHalted",
       "accounts": [
         {
@@ -8470,6 +8536,72 @@ export const IDL: Zeta = {
           "type": "u128"
         }
       ]
+    },
+    {
+      "name": "cancelAllMarketOrders",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "cancelAccounts",
+          "accounts": [
+            {
+              "name": "zetaGroup",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "market",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "bids",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "asks",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "eventQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": []
     },
     {
       "name": "cancelOrderHalted",


### PR DESCRIPTION
This PR adds a new instruction `cancelAllMarketOrders()` that will cancel all orders on a single market index in one go using Serum's `cpi::prune()`. The only other difference between `cancelAllMarketOrders()` and `cancelOrder()` is that here we don't provide a side + order ID. 

zeta-options PR: https://github.com/zetamarkets/zeta-options/pull/472
Fuze PR: https://github.com/zetamarkets/fuze/pull/28