### PR TITLE
Fix Kind enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.16.18",
+  "version": "0.16.19",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -5200,6 +5200,9 @@
           },
           {
             "name": "Future"
+          },
+          {
+            "name": "Perp"
           }
         ]
       }

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -5200,6 +5200,9 @@ export type Zeta = {
           },
           {
             "name": "Future"
+          },
+          {
+            "name": "Perp"
           }
         ]
       }
@@ -11399,6 +11402,9 @@ export const IDL: Zeta = {
           },
           {
             "name": "Future"
+          },
+          {
+            "name": "Perp"
           }
         ]
       }


### PR DESCRIPTION
Broke devnet due to IDL decoding, this fixes it. Mainnet is fine either way, having unused values in the enum doesn't cause any problems.

Already released as 0.16.19 yesterday.