### PR TITLE
Add `shx` to support Windows builds. Fix build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "author": "@zetamarkets",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "cp -r ../../target/idl/zeta.json ./src/idl/zeta.json && cp -r ../../target/types/zeta.ts ./src/types/. && ./node_modules/.bin/tsc",
-    "docs": "typedoc --tsconfig ./tsconfig.json && cp ./logo.png ./docs/logo.png",
-    "build-no-idl": "./node_modules/.bin/tsc"
+    "build": "shx cp -r ../../target/idl/zeta.json ./src/idl/zeta.json && shx cp -r ../../target/types/zeta.ts ./src/types/. && tsc",
+    "docs": "typedoc --tsconfig ./tsconfig.json && shx cp ./logo.png ./docs/logo.png",
+    "build-no-idl": "tsc"
   },
   "dependencies": {
     "@project-serum/anchor": "0.24.2",
@@ -19,6 +19,7 @@
     "@solana/spl-token": "0.1.6",
     "@solana/web3.js": "1.31.0",
     "bs58": "^4.0.1",
+    "buffer-layout": "^1.2.2",
     "lodash": "^4.17.21",
     "ts-node": "^10.7.0",
     "typescript": "^4.4.2"
@@ -27,6 +28,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.12",
     "mocha": "^9.1.1",
+    "shx": "^0.3.4",
     "typedoc": "^0.22.10"
   },
   "resolutions": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -585,7 +585,7 @@ export async function getTokenAccountInfo(
 
   if (accountInfo.delegateOption === 0) {
     accountInfo.delegate = null;
-    accountInfo.delegatedAmount = new u64(0);
+    accountInfo.delegatedAmount = 0;
   } else {
     accountInfo.delegate = new PublicKey(accountInfo.delegate);
     accountInfo.delegatedAmount = u64.fromBuffer(accountInfo.delegatedAmount);


### PR DESCRIPTION
- Adds `shx` support for `cp` support on windows.
- Change `tsc` to direct executable call instead of relative path.
- Add buffer layout to fix build.
- Fix u64 in build, maybe a new Node version thing.