### PR TITLE
Add optional blockhash option to placeOrder() + bump examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.17.1]
+
+- client: Add placeOrderWithBlockhash(), allowing the user to specify their own blockhash to avoid an RPC roundtrip. ([#166](https://github.com/zetamarkets/sdk/pull/166))
+- examples: Bump SDK version and webserver URL. ([#166](https://github.com/zetamarkets/sdk/pull/166))
+
 ## [0.17.0]
 
 - idl: add idl perp kind to prevent breaking changes.

--- a/examples/basic/.env
+++ b/examples/basic/.env
@@ -1,3 +1,3 @@
 network_url=https://api.devnet.solana.com
 program_id=BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7
-server_url=https://server.zeta.markets
+server_url=https://dex-devnet-webserver.zeta.markets

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.31.0",
-    "@zetamarkets/sdk": "^0.16.0",
+    "@zetamarkets/sdk": "^0.17.1",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.66.1",
-    "@zetamarkets/sdk": "^0.18.0-beta.15",
+    "@zetamarkets/sdk": "^0.18.0",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/cranking/package.json
+++ b/examples/cranking/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.66.1",
-    "@zetamarkets/sdk": "0.18.0-beta.15",
+    "@zetamarkets/sdk": "0.18.0",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/cranking/package.json
+++ b/examples/cranking/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.31.0",
-    "@zetamarkets/sdk": "^0.16.4",
+    "@zetamarkets/sdk": "^0.17.1",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/liquidator-example/.env
+++ b/examples/liquidator-example/.env
@@ -1,4 +1,4 @@
 check_interval_ms=5000
 connection=https://api.devnet.solana.com
 program_id=BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7
-server_url=https://server.zeta.markets
+server_url=https://dex-devnet-webserver.zeta.markets

--- a/examples/liquidator-example/package.json
+++ b/examples/liquidator-example/package.json
@@ -3,7 +3,7 @@
     "@project-serum/anchor": "0.22.1",
     "@solana/spl-token": "^0.1.6",
     "@solana/web3.js": "^1.66.1",
-    "@zetamarkets/sdk": "^0.18.0-beta.15",
+    "@zetamarkets/sdk": "^0.18.0",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",
     "typescript": "^4.4.3"

--- a/examples/liquidator-example/package.json
+++ b/examples/liquidator-example/package.json
@@ -3,7 +3,7 @@
     "@project-serum/anchor": "0.22.1",
     "@solana/spl-token": "^0.1.6",
     "@solana/web3.js": "^1.31.0",
-    "@zetamarkets/sdk":  "^0.16.0",
+    "@zetamarkets/sdk":  "^0.17.1",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",
     "typescript": "^4.4.3"

--- a/examples/settlement-print/.env
+++ b/examples/settlement-print/.env
@@ -1,4 +1,4 @@
 network=devnet
 network_url=https://api.devnet.solana.com
 program_id=BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7
-server_url=https://server.zeta.markets
+server_url=https://dex-devnet-webserver.zeta.markets

--- a/examples/settlement-print/package.json
+++ b/examples/settlement-print/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.31.0",
-    "@zetamarkets/sdk": "^0.16.0",
+    "@zetamarkets/sdk": "^0.17.1",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/settlement-print/package.json
+++ b/examples/settlement-print/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.66.1",
-    "@zetamarkets/sdk": "^0.18.0-beta.15",
+    "@zetamarkets/sdk": "^0.18.0",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/subscription/.env
+++ b/examples/subscription/.env
@@ -1,4 +1,4 @@
 network=devnet
 network_url=https://api.devnet.solana.com
 program_id=BG3oRikW8d16YjUEmX3ZxHm9SiJzrGtMhsSR8aCw1Cd7
-server_url=https://server.zeta.markets
+server_url=https://dex-devnet-webserver.zeta.markets

--- a/examples/subscription/package.json
+++ b/examples/subscription/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.66.1",
-    "@zetamarkets/sdk": "^0.18.0-beta.15",
+    "@zetamarkets/sdk": "^0.18.0",
     "bs58": "^4.0.1",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -411,7 +411,8 @@ export class Client {
         side,
         type,
         clientOrderId,
-        tag
+        tag,
+        blockhash
       );
     }
   }
@@ -423,7 +424,8 @@ export class Client {
     side: types.Side,
     type: types.OrderType = types.OrderType.LIMIT,
     clientOrderId = 0,
-    tag: String = constants.DEFAULT_ORDER_TAG
+    tag: String = constants.DEFAULT_ORDER_TAG,
+    blockhash?: string
   ): Promise<TransactionSignature> {
     return await this.getSubClient(asset).placePerpOrder(
       price,

--- a/src/client.ts
+++ b/src/client.ts
@@ -373,7 +373,8 @@ export class Client {
     side: types.Side,
     type: types.OrderType = types.OrderType.LIMIT,
     clientOrderId = 0,
-    tag: String = constants.DEFAULT_ORDER_TAG
+    tag: String = constants.DEFAULT_ORDER_TAG,
+    blockhash?: string
   ): Promise<TransactionSignature> {
     return await this.getSubClient(asset).placeOrderV3(
       this.marketIdentifierToPublicKey(asset, market),
@@ -382,7 +383,8 @@ export class Client {
       side,
       type,
       clientOrderId,
-      tag
+      tag,
+      blockhash
     );
   }
 

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -741,7 +741,8 @@ export class SubClient {
     side: types.Side,
     orderType: types.OrderType = types.OrderType.LIMIT,
     clientOrderId = 0,
-    tag: String = constants.DEFAULT_ORDER_TAG
+    tag: String = constants.DEFAULT_ORDER_TAG,
+    blockhash?: string
   ): Promise<TransactionSignature> {
     let tx = new Transaction();
     let marketIndex = this._subExchange.markets.getMarketIndex(market);
@@ -784,7 +785,14 @@ export class SubClient {
     tx.add(orderIx);
 
     let txId: TransactionSignature;
-    txId = await utils.processTransaction(this._parent.provider, tx);
+    txId = await utils.processTransaction(
+      this._parent.provider,
+      tx,
+      undefined,
+      undefined,
+      undefined,
+      blockhash
+    );
     this._openOrdersAccounts[marketIndex] = openOrdersPda;
     return txId;
   }

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -818,7 +818,8 @@ export class SubClient {
     side: types.Side,
     orderType: types.OrderType = types.OrderType.LIMIT,
     clientOrderId = 0,
-    tag: String = constants.DEFAULT_ORDER_TAG
+    tag: String = constants.DEFAULT_ORDER_TAG,
+    blockhash?: string
   ): Promise<TransactionSignature> {
     let tx = new Transaction();
     let market = Exchange.getPerpMarket(this._asset).address;
@@ -862,7 +863,14 @@ export class SubClient {
     tx.add(orderIx);
 
     let txId: TransactionSignature;
-    txId = await utils.processTransaction(this._parent.provider, tx);
+    txId = await utils.processTransaction(
+      this._parent.provider,
+      tx,
+      undefined,
+      undefined,
+      undefined,
+      blockhash
+    );
     this._openOrdersAccounts[marketIndex] = openOrdersPda;
     return txId;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -676,11 +676,18 @@ export async function processTransaction(
   tx: Transaction,
   signers?: Array<Signer>,
   opts?: ConfirmOptions,
-  useLedger: boolean = false
+  useLedger: boolean = false,
+  blockhash?: string
 ): Promise<TransactionSignature> {
   let txSig: TransactionSignature;
-  const blockhash = await provider.connection.getRecentBlockhash();
-  tx.recentBlockhash = blockhash.blockhash;
+
+  if (blockhash == undefined) {
+    const recentBlockhash = await provider.connection.getRecentBlockhash();
+    tx.recentBlockhash = recentBlockhash.blockhash;
+  } else {
+    tx.recentBlockhash = blockhash;
+  }
+
   tx.feePayer = useLedger
     ? Exchange.ledgerWallet.publicKey
     : provider.wallet.publicKey;


### PR DESCRIPTION
Calculating the blockhash involves a roundtrip to the RPC, which takes time. SDK users can lower their latency by pre-caching the blockhash instead. This PR adds an optional `blockhash?: string` to `utils.processTransaction()`. It's only used in `client.placeOrder()` for now but we can theoretically add it to any transaction if there's appetite for it.

This PR also bumps the examples - I noticed that the SDK version and webserver URL were out of date 😊 