### PR TITLE
Bump to newest web3 lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.17.1]
+
+- general: Bump solana-web3 package to 1.66.1 to fix some socket issues. ([#167](https://github.com/zetamarkets/sdk/pull/167))
+
 ## [0.17.0]
 
 - idl: add idl perp kind to prevent breaking changes.

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
-    "@solana/web3.js": "^1.31.0",
-    "@zetamarkets/sdk": "^0.16.0",
+    "@solana/web3.js": "^1.66.1",
+    "@zetamarkets/sdk": "file:../..",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/web3.js": "^1.66.1",
-    "@zetamarkets/sdk": "file:../..",
+    "@zetamarkets/sdk": "^0.16.0",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/cranking/package.json
+++ b/examples/cranking/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
-    "@solana/web3.js": "^1.31.0",
+    "@solana/web3.js": "^1.66.1",
     "@zetamarkets/sdk": "^0.16.4",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",

--- a/examples/liquidator-example/package.json
+++ b/examples/liquidator-example/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
     "@solana/spl-token": "^0.1.6",
-    "@solana/web3.js": "^1.31.0",
+    "@solana/web3.js": "^1.66.1",
     "@zetamarkets/sdk":  "^0.16.0",
     "dotenv": "^10.0.0",
     "ts-node": "^7.0.1",

--- a/examples/settlement-print/package.json
+++ b/examples/settlement-print/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
-    "@solana/web3.js": "^1.31.0",
+    "@solana/web3.js": "^1.66.1",
     "@zetamarkets/sdk": "^0.16.0",
     "buffer-layout": "^1.2.2",
     "dotenv": "^10.0.0",

--- a/examples/subscription/package.json
+++ b/examples/subscription/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@project-serum/anchor": "0.22.1",
-    "@solana/web3.js": "^1.31.0",
+    "@solana/web3.js": "^1.66.1",
     "@zetamarkets/sdk": "^0.16.0",
     "bs58": "^4.0.1",
     "buffer-layout": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,7 +17,7 @@
     "@project-serum/serum": "0.13.55",
     "@solana/buffer-layout": "4.0.0",
     "@solana/spl-token": "0.1.6",
-    "@solana/web3.js": "1.31.0",
+    "@solana/web3.js": "1.66.1",
     "bs58": "^4.0.1",
     "lodash": "^4.17.21",
     "ts-node": "^10.7.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -585,7 +585,7 @@ export async function getTokenAccountInfo(
 
   if (accountInfo.delegateOption === 0) {
     accountInfo.delegate = null;
-    accountInfo.delegatedAmount = new u64(0);
+    accountInfo.delegatedAmount = 0;
   } else {
     accountInfo.delegate = new PublicKey(accountInfo.delegate);
     accountInfo.delegatedAmount = u64.fromBuffer(accountInfo.delegatedAmount);


### PR DESCRIPTION
Bump solana-web3 library to fix a recursion issue we saw: https://github.com/solana-labs/solana/pull/28428

No issues in basic-example.ts with locally built SDK, and (backup mainnet) dex-webserver & dex-server with beta release of this PR. Released as 0.17.1-beta.3 if you want to try yourself 😊 