### PR TITLE
Add crank limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## [Unreleased]
 
+## [0.18.1]
+
+- utils: Add an optional limit to the amount of events cranked at once. ([#172](https://github.com/zetamarkets/sdk/pull/172))
+
 ## [0.18.0]
 
 - client: Better cancelAllOrders() functionality. ([#169](https://github.com/zetamarkets/sdk/pull/169))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1109,7 +1109,8 @@ export async function settleUsers(
 export async function crankMarket(
   asset: Asset,
   marketIndex: number,
-  openOrdersToMargin?: Map<PublicKey, PublicKey>
+  openOrdersToMargin?: Map<PublicKey, PublicKey>,
+  crankLimit?: number
 ) {
   let market = Exchange.getMarket(asset, marketIndex);
   let eventQueue = await market.serumMarket.loadEventQueue(Exchange.connection);
@@ -1122,6 +1123,12 @@ export async function crankMarket(
     market.kind == types.Kind.PERP
       ? constants.CRANK_PERP_ACCOUNT_LIMIT
       : constants.CRANK_ACCOUNT_LIMIT;
+
+  // Manually defined crankLimit will override
+  if (crankLimit) {
+    limit = crankLimit;
+  }
+
   for (var i = 0; i < eventQueue.length; i++) {
     openOrdersSet.add(eventQueue[i].openOrders.toString());
     if (openOrdersSet.size == limit) {


### PR DESCRIPTION
Add an optional limit to the amount of events cranked at once in `utils.crankMarket()`