### PR TITLE
Delegated accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 Version changes are pinned to SDK releases.
 
+## [0.19.4] 2023-01-18
+
+- general: Add delegated account functionality to program and SDK. ([#187](https://github.com/zetamarkets/sdk/pull/187))
+
 ## [0.19.3] 2023-01-09
 
 - client: add perp functionality to all cancel+place functions in subclient. ([#186](https://github.com/zetamarkets/sdk/pull/186))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 Version changes are pinned to SDK releases.
 
-## [0.19.4] 2023-01-18
+## [0.20.0] 2023-01-18
 
 - general: Add delegated account functionality to program and SDK. ([#187](https://github.com/zetamarkets/sdk/pull/187))
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -367,7 +367,8 @@ export class Client {
     price: number,
     size: number,
     side: types.Side,
-    options: types.OrderOptions = types.defaultOrderOptions()
+    options: types.OrderOptions = types.defaultOrderOptions(),
+    onBehalfOfMarginAccountAddress: PublicKey = undefined
   ): Promise<TransactionSignature> {
     let marketPubkey = this.marketIdentifierToPublicKey(asset, market);
     if (marketPubkey == Exchange.getPerpMarket(asset).address) {
@@ -375,7 +376,8 @@ export class Client {
         price,
         size,
         side,
-        options
+        options,
+        onBehalfOfMarginAccountAddress
       );
     } else {
       return await this.getSubClient(asset).placeOrder(
@@ -393,13 +395,15 @@ export class Client {
     price: number,
     size: number,
     side: types.Side,
-    options: types.OrderOptions = types.defaultOrderOptions()
+    options: types.OrderOptions = types.defaultOrderOptions(),
+    onBehalfOfMarginAccountAddress: PublicKey = undefined
   ): Promise<TransactionSignature> {
     return await this.getSubClient(asset).placePerpOrder(
       price,
       size,
       side,
-      options
+      options,
+      onBehalfOfMarginAccountAddress
     );
   }
 
@@ -455,6 +459,13 @@ export class Client {
     return this.getSubClient(asset).createCancelAllMarketOrdersInstruction(
       this.marketIdentifierToIndex(asset, market)
     );
+  }
+
+  public async editDelegatedPubkey(
+    asset: Asset,
+    delegatedPubkey: PublicKey
+  ): Promise<TransactionSignature> {
+    return await this.getSubClient(asset).editDelegatedPubkey(delegatedPubkey);
   }
 
   public async migrateFunds(

--- a/src/client.ts
+++ b/src/client.ts
@@ -385,7 +385,8 @@ export class Client {
         price,
         size,
         side,
-        options
+        options,
+        onBehalfOfUser
       );
     }
   }
@@ -396,14 +397,14 @@ export class Client {
     size: number,
     side: types.Side,
     options: types.OrderOptions = types.defaultOrderOptions(),
-    onBehalfOfMarginAccountAddress: PublicKey = undefined
+    onBehalfOfUser: PublicKey = undefined
   ): Promise<TransactionSignature> {
     return await this.getSubClient(asset).placePerpOrder(
       price,
       size,
       side,
       options,
-      onBehalfOfMarginAccountAddress
+      onBehalfOfUser
     );
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -152,21 +152,21 @@ export class Client {
   ): Promise<Client> {
     let client = new Client(connection, wallet, opts);
 
-    let user = wallet.publicKey;
+    let owner = wallet.publicKey;
     if (delegator != undefined) {
-      user = delegator;
+      owner = delegator;
       client._delegatorKey = delegator;
     }
 
     client._usdcAccountAddress = await utils.getAssociatedTokenAddress(
       Exchange.usdcMintAddress,
-      user
+      owner
     );
 
     client._whitelistDepositAddress = undefined;
     try {
       let [whitelistDepositAddress, _whitelistTradingFeesNonce] =
-        await utils.getUserWhitelistDepositAccount(Exchange.programId, user);
+        await utils.getUserWhitelistDepositAccount(Exchange.programId, owner);
       await Exchange.program.account.whitelistDepositAccount.fetch(
         whitelistDepositAddress
       );
@@ -179,7 +179,7 @@ export class Client {
       let [whitelistTradingFeesAddress, _whitelistTradingFeesNonce] =
         await utils.getUserWhitelistTradingFeesAccount(
           Exchange.programId,
-          user
+          owner
         );
       await Exchange.program.account.whitelistTradingFeesAccount.fetch(
         whitelistTradingFeesAddress
@@ -194,7 +194,7 @@ export class Client {
           asset,
           client,
           connection,
-          user,
+          owner,
           callback,
           throttle
         );

--- a/src/client.ts
+++ b/src/client.ts
@@ -148,13 +148,13 @@ export class Client {
     opts: ConfirmOptions = utils.defaultCommitment(),
     callback: (asset: Asset, type: EventType, data: any) => void = undefined,
     throttle: boolean = false,
-    onBehalfOfUser: PublicKey = undefined
+    delegator: PublicKey = undefined
   ): Promise<Client> {
     let client = new Client(connection, wallet, opts);
 
-    if (onBehalfOfUser != undefined) {
-      wallet = new types.DelegatedWallet(onBehalfOfUser);
-      client._delegatedKey = onBehalfOfUser;
+    if (delegator != undefined) {
+      wallet = new types.DelegatedWallet(delegator);
+      client._delegatedKey = delegator;
     }
 
     client._usdcAccountAddress = await utils.getAssociatedTokenAddress(

--- a/src/client.ts
+++ b/src/client.ts
@@ -152,23 +152,21 @@ export class Client {
   ): Promise<Client> {
     let client = new Client(connection, wallet, opts);
 
+    let user = wallet.publicKey;
     if (delegator != undefined) {
-      wallet = new types.DelegatedWallet(delegator);
+      user = delegator;
       client._delegatorKey = delegator;
     }
 
     client._usdcAccountAddress = await utils.getAssociatedTokenAddress(
       Exchange.usdcMintAddress,
-      wallet.publicKey
+      user
     );
 
     client._whitelistDepositAddress = undefined;
     try {
       let [whitelistDepositAddress, _whitelistTradingFeesNonce] =
-        await utils.getUserWhitelistDepositAccount(
-          Exchange.programId,
-          wallet.publicKey
-        );
+        await utils.getUserWhitelistDepositAccount(Exchange.programId, user);
       await Exchange.program.account.whitelistDepositAccount.fetch(
         whitelistDepositAddress
       );
@@ -181,7 +179,7 @@ export class Client {
       let [whitelistTradingFeesAddress, _whitelistTradingFeesNonce] =
         await utils.getUserWhitelistTradingFeesAccount(
           Exchange.programId,
-          wallet.publicKey
+          user
         );
       await Exchange.program.account.whitelistTradingFeesAccount.fetch(
         whitelistTradingFeesAddress
@@ -196,7 +194,7 @@ export class Client {
           asset,
           client,
           connection,
-          wallet,
+          user,
           callback,
           throttle
         );

--- a/src/client.ts
+++ b/src/client.ts
@@ -69,8 +69,8 @@ export class Client {
    * Client margin account address.
    */
   public get publicKey(): PublicKey {
-    if (this._delegatedKey != undefined) {
-      return this._delegatedKey;
+    if (this._delegatorKey != undefined) {
+      return this._delegatorKey;
     }
     return this.provider.wallet.publicKey;
   }
@@ -123,10 +123,10 @@ export class Client {
     return this._subClients;
   }
 
-  public get delegatedKey(): PublicKey {
-    return this._delegatedKey;
+  public get delegatorKey(): PublicKey {
+    return this._delegatorKey;
   }
-  public _delegatedKey: PublicKey = undefined;
+  public _delegatorKey: PublicKey = undefined;
 
   private constructor(
     connection: Connection,
@@ -154,7 +154,7 @@ export class Client {
 
     if (delegator != undefined) {
       wallet = new types.DelegatedWallet(delegator);
-      client._delegatedKey = delegator;
+      client._delegatorKey = delegator;
     }
 
     client._usdcAccountAddress = await utils.getAssociatedTokenAddress(

--- a/src/client.ts
+++ b/src/client.ts
@@ -368,7 +368,7 @@ export class Client {
     size: number,
     side: types.Side,
     options: types.OrderOptions = types.defaultOrderOptions(),
-    onBehalfOfMarginAccountAddress: PublicKey = undefined
+    onBehalfOfUser: PublicKey = undefined
   ): Promise<TransactionSignature> {
     let marketPubkey = this.marketIdentifierToPublicKey(asset, market);
     if (marketPubkey == Exchange.getPerpMarket(asset).address) {
@@ -377,7 +377,7 @@ export class Client {
         size,
         side,
         options,
-        onBehalfOfMarginAccountAddress
+        onBehalfOfUser
       );
     } else {
       return await this.getSubClient(asset).placeOrder(
@@ -968,6 +968,14 @@ export class Client {
 
   public getMarginAccountAddress(asset: Asset): PublicKey {
     return this.getSubClient(asset).marginAccountAddress;
+  }
+
+  public getMarginAccountAddresses(): PublicKey[] {
+    let addresses = [];
+    for (var asset of Exchange.assets) {
+      addresses.push(this.getSubClient(asset).marginAccountAddress);
+    }
+    return addresses;
   }
 
   public async initializeReferrerAccount() {

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -4168,6 +4168,42 @@
         }
       ],
       "args": []
+    },
+    {
+      "name": "editDelegatedPubkey",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "newKey",
+          "type": "publicKey"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -4893,6 +4929,10 @@
             "type": {
               "defined": "AnchorDecimal"
             }
+          },
+          {
+            "name": "delegatedPubkey",
+            "type": "publicKey"
           },
           {
             "name": "padding",

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -4939,7 +4939,7 @@
             "type": {
               "array": [
                 "u8",
-                370
+                338
               ]
             }
           }
@@ -7291,6 +7291,11 @@
       "code": 6128,
       "name": "ForceCancelExpiredTIFOrdersOnly",
       "msg": "Can only force cancel expired TIF orders"
+    },
+    {
+      "code": 6129,
+      "name": "InvalidPlaceOrderAuthority",
+      "msg": "Invalid place order authority"
     }
   ]
 }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -6354,6 +6354,23 @@
           }
         ]
       }
+    },
+    {
+      "name": "ValidationType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Place"
+          },
+          {
+            "name": "Cancel"
+          },
+          {
+            "name": "OpenOrders"
+          }
+        ]
+      }
     }
   ],
   "events": [
@@ -7296,6 +7313,11 @@
       "code": 6129,
       "name": "InvalidPlaceOrderAuthority",
       "msg": "Invalid place order authority"
+    },
+    {
+      "code": 6130,
+      "name": "InvalidOpenOrdersAuthority",
+      "msg": "Invalid open orders authority"
     }
   ]
 }

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -195,6 +195,7 @@ export async function initializeOpenOrdersIx(
   asset: Asset,
   market: PublicKey,
   userKey: PublicKey,
+  authority: PublicKey,
   marginAccount: PublicKey
 ): Promise<[TransactionInstruction, PublicKey]> {
   const [openOrdersPda, _openOrdersNonce] = await utils.getOpenOrders(
@@ -217,8 +218,8 @@ export async function initializeOpenOrdersIx(
         systemProgram: SystemProgram.programId,
         openOrders: openOrdersPda,
         marginAccount: marginAccount,
-        authority: userKey,
-        payer: userKey,
+        authority: authority,
+        payer: authority,
         market: market,
         rent: SYSVAR_RENT_PUBKEY,
         serumAuthority: Exchange.serumAuthority,

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -2238,6 +2238,23 @@ export async function toggleMarketMakerIx(
   });
 }
 
+export function editDelegatedPubkeyIx(
+  asset: Asset,
+  delegatedPubkey: PublicKey,
+  marginAccount: PublicKey,
+  authority: PublicKey
+): TransactionInstruction {
+  return Exchange.program.instruction.editDelegatedPubkey(delegatedPubkey, {
+    accounts: {
+      state: Exchange.stateAddress,
+      zetaGroup: Exchange.getZetaGroupAddress(asset),
+      marginAccount,
+      tokenProgram: TOKEN_PROGRAM_ID,
+      authority,
+    },
+  });
+}
+
 export interface ExpireSeriesOverrideArgs {
   settlementNonce: number;
   settlementPrice: anchor.BN;

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -166,6 +166,7 @@ export interface MarginAccount {
   asset: any;
   accountType: any;
   lastFundingDelta: AnchorDecimal;
+  delegatedPubkey: PublicKey;
   padding: Array<number>;
 }
 

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -679,9 +679,7 @@ export class SubClient {
       undefined,
       options.blockhash
     );
-    // if (this.parent.delegatedAccount == undefined) {
     this._openOrdersAccounts[marketIndex] = openOrdersPda;
-    // }
     return txId;
   }
 
@@ -1424,7 +1422,7 @@ export class SubClient {
    * Instruction builder for cancelAllOrders()
    * Returns a list of instructions cancelling all of this subclient's orders
    */
-  public async cancelAllOrdersIxs(): Promise<TransactionInstruction[]> {
+  public cancelAllOrdersIxs(): TransactionInstruction[] {
     let ixs = [];
     for (var i = 0; i < this._orders.length; i++) {
       let order = this._orders[i];
@@ -1446,7 +1444,7 @@ export class SubClient {
    * Instruction builder for cancelAllOrdersNoError()
    * Returns a list of instructions cancelling all of this subclient's orders
    */
-  public async cancelAllOrdersNoErrorIxs(): Promise<TransactionInstruction[]> {
+  public cancelAllOrdersNoErrorIxs(): TransactionInstruction[] {
     let ixs = [];
     for (var i = 0; i < this._orders.length; i++) {
       let order = this._orders[i];
@@ -1472,7 +1470,7 @@ export class SubClient {
     // on 4 separate markets
     // Compute is fine.
     let txs = utils.splitIxsIntoTx(
-      await this.cancelAllOrdersIxs(),
+      this.cancelAllOrdersIxs(),
       constants.MAX_CANCELS_PER_TX
     );
     let txIds: string[] = [];
@@ -1492,7 +1490,7 @@ export class SubClient {
     // on 4 separate markets
     // Compute is fine.
     let txs = utils.splitIxsIntoTx(
-      await this.cancelAllOrdersNoErrorIxs(),
+      this.cancelAllOrdersNoErrorIxs(),
       constants.MAX_CANCELS_PER_TX
     );
     let txIds: string[] = [];

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -383,6 +383,7 @@ export class SubClient {
    * @param amount  the native amount to deposit (6 decimals fixed point)
    */
   public async deposit(amount: number): Promise<TransactionSignature> {
+    this.delegatedCheck();
     // Check if the user has a USDC account.
     let tx = new Transaction();
     if (this._marginAccount === null) {
@@ -391,7 +392,7 @@ export class SubClient {
         instructions.initializeMarginAccountIx(
           this._subExchange.zetaGroupAddress,
           this._marginAccountAddress,
-          this._parent.publicKey
+          this._parent.provider.wallet.publicKey
         )
       );
     }
@@ -401,7 +402,7 @@ export class SubClient {
         amount,
         this._marginAccountAddress,
         this._parent.usdcAccountAddress,
-        this._parent.publicKey,
+        this._parent.provider.wallet.publicKey,
         this._parent.whitelistDepositAddress
       )
     );
@@ -413,6 +414,7 @@ export class SubClient {
    * Closes a subClient's margin account
    */
   public async closeMarginAccount(): Promise<TransactionSignature> {
+    this.delegatedCheck();
     if (this._marginAccount === null) {
       throw Error("User has no margin account to close");
     }
@@ -420,7 +422,7 @@ export class SubClient {
     let tx = new Transaction().add(
       instructions.closeMarginAccountIx(
         this.asset,
-        this._parent.publicKey,
+        this._parent.provider.wallet.publicKey,
         this._marginAccountAddress
       )
     );
@@ -433,6 +435,7 @@ export class SubClient {
    * Closes a subClient's spread account
    */
   public async closeSpreadAccount(): Promise<TransactionSignature> {
+    this.delegatedCheck();
     if (this._spreadAccount === null) {
       throw Error("User has no spread account to close");
     }
@@ -443,14 +446,14 @@ export class SubClient {
         subExchange.zetaGroupAddress,
         this.marginAccountAddress,
         this._spreadAccountAddress,
-        this._parent.publicKey
+        this._parent.provider.wallet.publicKey
       )
     );
     tx.add(
       instructions.closeSpreadAccountIx(
         subExchange.zetaGroupAddress,
         this._spreadAccountAddress,
-        this._parent.publicKey
+        this._parent.provider.wallet.publicKey
       )
     );
     let txId = await utils.processTransaction(this._parent.provider, tx);
@@ -462,6 +465,7 @@ export class SubClient {
    * @param amount  the native amount to withdraw (6 dp)
    */
   public async withdraw(amount: number): Promise<TransactionSignature> {
+    this.delegatedCheck();
     let tx = new Transaction();
     tx.add(
       instructions.withdrawIx(
@@ -469,7 +473,7 @@ export class SubClient {
         amount,
         this._marginAccountAddress,
         this._parent.usdcAccountAddress,
-        this._parent.publicKey
+        this._parent.provider.wallet.publicKey
       )
     );
     return await utils.processTransaction(this._parent.provider, tx);
@@ -479,6 +483,7 @@ export class SubClient {
    * Withdraws the entirety of the subClient's margin account and then closes it.
    */
   public async withdrawAndCloseMarginAccount(): Promise<TransactionSignature> {
+    this.delegatedCheck();
     if (this._marginAccount === null) {
       throw Error("User has no margin account to withdraw or close.");
     }
@@ -489,13 +494,13 @@ export class SubClient {
         this._marginAccount.balance.toNumber(),
         this._marginAccountAddress,
         this._parent.usdcAccountAddress,
-        this._parent.publicKey
+        this._parent.provider.wallet.publicKey
       )
     );
     tx.add(
       instructions.closeMarginAccountIx(
         this.asset,
-        this._parent.publicKey,
+        this._parent.provider.wallet.publicKey,
         this._marginAccountAddress
       )
     );
@@ -518,6 +523,7 @@ export class SubClient {
     side: types.Side,
     tag: String = constants.DEFAULT_ORDER_TAG
   ): Promise<TransactionSignature> {
+    this.delegatedCheck();
     let tx = new Transaction();
     let subExchange = this._subExchange;
     let marketIndex = subExchange.markets.getMarketIndex(market);
@@ -531,7 +537,7 @@ export class SubClient {
         this.asset,
         market,
         this._parent.publicKey,
-        this._parent.publicKey,
+        this._parent.provider.wallet.publicKey,
         this.marginAccountAddress
       );
       openOrdersPda = _openOrdersPda;
@@ -551,7 +557,7 @@ export class SubClient {
       tag,
       0,
       this.marginAccountAddress,
-      this._parent.publicKey,
+      this._parent.provider.wallet.publicKey,
       openOrdersPda,
       this._parent.whitelistTradingFeesAddress
     );
@@ -564,7 +570,7 @@ export class SubClient {
         instructions.initializeSpreadAccountIx(
           subExchange.zetaGroupAddress,
           this.spreadAccountAddress,
-          this._parent.publicKey
+          this._parent.provider.wallet.publicKey
         )
       );
     }
@@ -583,7 +589,7 @@ export class SubClient {
         subExchange.zetaGroupAddress,
         this.marginAccountAddress,
         this.spreadAccountAddress,
-        this._parent.publicKey,
+        this._parent.provider.wallet.publicKey,
         subExchange.greeksAddress,
         subExchange.zetaGroup.oracle,
         types.MovementType.LOCK,
@@ -792,7 +798,7 @@ export class SubClient {
     return instructions.cancelOrderNoErrorIx(
       this.asset,
       marketIndex,
-      this._parent.publicKey,
+      this._parent.provider.wallet.publicKey,
       this._marginAccountAddress,
       this._openOrdersAccounts[marketIndex],
       orderId,
@@ -806,7 +812,7 @@ export class SubClient {
     return instructions.cancelAllMarketOrdersIx(
       this.asset,
       marketIndex,
-      this._parent.publicKey,
+      this._parent.provider.wallet.publicKey,
       this._marginAccountAddress,
       this._openOrdersAccounts[marketIndex]
     );
@@ -841,7 +847,7 @@ export class SubClient {
       options.tag != undefined ? options.tag : constants.DEFAULT_ORDER_TAG,
       tifOffsetToUse,
       this.marginAccountAddress,
-      this._parent.publicKey,
+      this._parent.provider.wallet.publicKey,
       this._openOrdersAccounts[marketIndex],
       this._parent.whitelistTradingFeesAddress
     );
@@ -883,7 +889,7 @@ export class SubClient {
       options.tag != undefined ? options.tag : constants.DEFAULT_ORDER_TAG,
       tifOffset,
       this.marginAccountAddress,
-      this._parent.publicKey,
+      this._parent.provider.wallet.publicKey,
       this._openOrdersAccounts[constants.PERP_INDEX],
       this._parent.whitelistTradingFeesAddress
     );
@@ -1229,6 +1235,7 @@ export class SubClient {
   public async closeOpenOrdersAccount(
     market: PublicKey
   ): Promise<TransactionSignature> {
+    this.delegatedCheck();
     let marketIndex = this._subExchange.markets.getMarketIndex(market);
     if (this._openOrdersAccounts[marketIndex].equals(PublicKey.default)) {
       throw Error("User has no open orders account for this market!");
@@ -1254,7 +1261,7 @@ export class SubClient {
       await instructions.closeOpenOrdersIx(
         this.asset,
         market,
-        this._parent.publicKey,
+        this._parent.provider.wallet.publicKey,
         this.marginAccountAddress,
         this._openOrdersAccounts[marketIndex]
       )
@@ -1271,6 +1278,7 @@ export class SubClient {
   public async closeMultipleOpenOrdersAccount(
     markets: PublicKey[]
   ): Promise<TransactionSignature[]> {
+    this.delegatedCheck();
     let combinedIxs: TransactionInstruction[] = [];
     let subExchange = this._subExchange;
     for (var i = 0; i < markets.length; i++) {
@@ -1293,7 +1301,7 @@ export class SubClient {
       let closeIx = await instructions.closeOpenOrdersIx(
         this.asset,
         market,
-        this._parent.publicKey,
+        this._parent.provider.wallet.publicKey,
         this.marginAccountAddress,
         this._openOrdersAccounts[marketIndex]
       );
@@ -1335,6 +1343,7 @@ export class SubClient {
     orderId: anchor.BN,
     side: types.Side
   ): Promise<TransactionSignature> {
+    this.delegatedCheck();
     let marginAccount = (await Exchange.program.account.marginAccount.fetch(
       marginAccountToCancel
     )) as unknown as MarginAccount;
@@ -1370,6 +1379,7 @@ export class SubClient {
     market: PublicKey,
     marginAccountToCancel: PublicKey
   ): Promise<TransactionSignature> {
+    this.delegatedCheck();
     let marginAccount = (await Exchange.program.account.marginAccount.fetch(
       marginAccountToCancel
     )) as unknown as MarginAccount;
@@ -1405,10 +1415,11 @@ export class SubClient {
     liquidatedMarginAccount: PublicKey,
     size: number
   ): Promise<TransactionSignature> {
+    this.delegatedCheck();
     let tx = new Transaction();
     let ix = instructions.liquidateIx(
       this.asset,
-      this._parent.publicKey,
+      this._parent.provider.wallet.publicKey,
       this._marginAccountAddress,
       market,
       liquidatedMarginAccount,
@@ -1511,6 +1522,7 @@ export class SubClient {
     movementType: types.MovementType,
     movements: instructions.PositionMovementArg[]
   ): Promise<TransactionSignature> {
+    this.delegatedCheck();
     let tx = this.getPositionMovementTx(movementType, movements);
     return await utils.processTransaction(this._parent.provider, tx);
   }
@@ -1524,6 +1536,7 @@ export class SubClient {
     movementType: types.MovementType,
     movements: instructions.PositionMovementArg[]
   ): Promise<PositionMovementEvent> {
+    this.delegatedCheck();
     let tx = this.getPositionMovementTx(movementType, movements);
     let response = await utils.simulateTransaction(this._parent.provider, tx);
 
@@ -1547,6 +1560,7 @@ export class SubClient {
     movementType: types.MovementType,
     movements: instructions.PositionMovementArg[]
   ): Transaction {
+    this.delegatedCheck();
     if (movements.length > constants.MAX_POSITION_MOVEMENTS) {
       throw new Error(
         `Max position movements exceeded. Max = ${constants.MAX_POSITION_MOVEMENTS} < ${movements.length}`
@@ -1563,7 +1577,7 @@ export class SubClient {
         instructions.initializeSpreadAccountIx(
           subExchange.zetaGroupAddress,
           this.spreadAccountAddress,
-          this._parent.publicKey
+          this._parent.provider.wallet.publicKey
         )
       );
     }
@@ -1574,7 +1588,7 @@ export class SubClient {
         subExchange.zetaGroupAddress,
         this.marginAccountAddress,
         this.spreadAccountAddress,
-        this._parent.publicKey,
+        this._parent.provider.wallet.publicKey,
         subExchange.greeksAddress,
         subExchange.zetaGroup.oracle,
         movementType,
@@ -1589,12 +1603,13 @@ export class SubClient {
    * Transfers any non required balance in the spread account to margin account.
    */
   public async transferExcessSpreadBalance(): Promise<TransactionSignature> {
+    this.delegatedCheck();
     let tx = new Transaction().add(
       instructions.transferExcessSpreadBalanceIx(
         this._subExchange.zetaGroupAddress,
         this.marginAccountAddress,
         this.spreadAccountAddress,
-        this._parent.publicKey
+        this._parent.provider.wallet.publicKey
       )
     );
     return await utils.processTransaction(this._parent.provider, tx);
@@ -1861,6 +1876,14 @@ export class SubClient {
         this._spreadAccountSubscriptionId
       );
       this._spreadAccountSubscriptionId = undefined;
+    }
+  }
+
+  private delegatedCheck() {
+    if (this._parent.delegatorKey) {
+      throw Error(
+        "Function not supported by delegated client. Please load without 'delegator' argument"
+      );
     }
   }
 }

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -191,7 +191,7 @@ export class SubClient {
     asset: Asset,
     parent: Client,
     connection: Connection,
-    wallet: types.Wallet,
+    user: PublicKey,
     callback: (asset: Asset, type: EventType, data: any) => void = undefined,
     throttle: boolean = false
   ): Promise<SubClient> {
@@ -200,14 +200,14 @@ export class SubClient {
       await utils.getMarginAccount(
         Exchange.programId,
         subClient._subExchange.zetaGroupAddress,
-        wallet.publicKey
+        user
       );
 
     let [spreadAccountAddress, _spreadAccountNonce] =
       await utils.getSpreadAccount(
         Exchange.programId,
         subClient._subExchange.zetaGroupAddress,
-        wallet.publicKey
+        user
       );
 
     subClient._marginAccountAddress = marginAccountAddress;

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -1572,6 +1572,7 @@ export class SubClient {
     let asset = this._asset;
     let openOrdersAccounts = this._openOrdersAccounts;
     let marginAccountAddress = this.marginAccountAddress;
+    let orders = this._orders;
 
     if (onBehalfOfUser != undefined) {
       let delegatedClient = await Client.load(
@@ -1581,12 +1582,12 @@ export class SubClient {
 
       marginAccountAddress = delegatedClient.getMarginAccountAddress(asset);
       openOrdersAccounts = delegatedClient.getOpenOrdersAccounts(asset);
-
+      orders = delegatedClient.getOrders(asset);
       await delegatedClient.close();
     }
 
-    for (var i = 0; i < this._orders.length; i++) {
-      let order = this._orders[i];
+    for (var i = 0; i < orders.length; i++) {
+      let order = orders[i];
       let ix = instructions.cancelOrderIx(
         asset,
         order.marketIndex,
@@ -1612,6 +1613,7 @@ export class SubClient {
     let asset = this._asset;
     let openOrdersAccounts = this._openOrdersAccounts;
     let marginAccountAddress = this.marginAccountAddress;
+    let orders = this._orders;
 
     if (onBehalfOfUser != undefined) {
       let delegatedClient = await Client.load(
@@ -1621,13 +1623,13 @@ export class SubClient {
 
       marginAccountAddress = delegatedClient.getMarginAccountAddress(asset);
       openOrdersAccounts = delegatedClient.getOpenOrdersAccounts(asset);
-
+      orders = delegatedClient.getOrders(asset);
       await delegatedClient.close();
     }
 
-    for (var i = 0; i < this._orders.length; i++) {
-      let order = this._orders[i];
-      let ix = instructions.cancelOrderIx(
+    for (var i = 0; i < orders.length; i++) {
+      let order = orders[i];
+      let ix = instructions.cancelOrderNoErrorIx(
         asset,
         order.marketIndex,
         this._parent.publicKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,26 +32,6 @@ export class DummyWallet implements Wallet {
   }
 }
 
-export class DelegatedWallet implements Wallet {
-  constructor(delegatedPublicKey: PublicKey) {
-    this._delegatedPublicKey = delegatedPublicKey;
-  }
-
-  async signTransaction(_tx: Transaction): Promise<Transaction> {
-    throw Error("Not supported by delegated wallet!");
-  }
-
-  async signAllTransactions(_txs: Transaction[]): Promise<Transaction[]> {
-    throw Error("Not supported by delegated wallet!");
-  }
-
-  get publicKey(): PublicKey {
-    return this._delegatedPublicKey;
-  }
-
-  public _delegatedPublicKey: PublicKey;
-}
-
 export enum OrderType {
   LIMIT,
   POSTONLY,

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,26 @@ export class DummyWallet implements Wallet {
   }
 }
 
+export class DelegatedWallet implements Wallet {
+  constructor(delegatedPublicKey: PublicKey) {
+    this._delegatedPublicKey = delegatedPublicKey;
+  }
+
+  async signTransaction(_tx: Transaction): Promise<Transaction> {
+    throw Error("Not supported by delegated wallet!");
+  }
+
+  async signAllTransactions(_txs: Transaction[]): Promise<Transaction[]> {
+    throw Error("Not supported by delegated wallet!");
+  }
+
+  get publicKey(): PublicKey {
+    return this._delegatedPublicKey;
+  }
+
+  public _delegatedPublicKey: PublicKey;
+}
+
 export enum OrderType {
   LIMIT,
   POSTONLY,

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -6354,6 +6354,23 @@ export type Zeta = {
           }
         ]
       }
+    },
+    {
+      "name": "ValidationType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Place"
+          },
+          {
+            "name": "Cancel"
+          },
+          {
+            "name": "OpenOrders"
+          }
+        ]
+      }
     }
   ],
   "events": [
@@ -7296,6 +7313,11 @@ export type Zeta = {
       "code": 6129,
       "name": "InvalidPlaceOrderAuthority",
       "msg": "Invalid place order authority"
+    },
+    {
+      "code": 6130,
+      "name": "InvalidOpenOrdersAuthority",
+      "msg": "Invalid open orders authority"
     }
   ]
 };
@@ -13656,6 +13678,23 @@ export const IDL: Zeta = {
           }
         ]
       }
+    },
+    {
+      "name": "ValidationType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Place"
+          },
+          {
+            "name": "Cancel"
+          },
+          {
+            "name": "OpenOrders"
+          }
+        ]
+      }
     }
   ],
   "events": [
@@ -14598,6 +14637,11 @@ export const IDL: Zeta = {
       "code": 6129,
       "name": "InvalidPlaceOrderAuthority",
       "msg": "Invalid place order authority"
+    },
+    {
+      "code": 6130,
+      "name": "InvalidOpenOrdersAuthority",
+      "msg": "Invalid open orders authority"
     }
   ]
 };

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -4168,6 +4168,42 @@ export type Zeta = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "editDelegatedPubkey",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "newKey",
+          "type": "publicKey"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -4893,6 +4929,10 @@ export type Zeta = {
             "type": {
               "defined": "AnchorDecimal"
             }
+          },
+          {
+            "name": "delegatedPubkey",
+            "type": "publicKey"
           },
           {
             "name": "padding",
@@ -11425,6 +11465,42 @@ export const IDL: Zeta = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "editDelegatedPubkey",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "zetaGroup",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        }
+      ],
+      "args": [
+        {
+          "name": "newKey",
+          "type": "publicKey"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -12150,6 +12226,10 @@ export const IDL: Zeta = {
             "type": {
               "defined": "AnchorDecimal"
             }
+          },
+          {
+            "name": "delegatedPubkey",
+            "type": "publicKey"
           },
           {
             "name": "padding",

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -4939,7 +4939,7 @@ export type Zeta = {
             "type": {
               "array": [
                 "u8",
-                370
+                338
               ]
             }
           }
@@ -7291,6 +7291,11 @@ export type Zeta = {
       "code": 6128,
       "name": "ForceCancelExpiredTIFOrdersOnly",
       "msg": "Can only force cancel expired TIF orders"
+    },
+    {
+      "code": 6129,
+      "name": "InvalidPlaceOrderAuthority",
+      "msg": "Invalid place order authority"
     }
   ]
 };
@@ -12236,7 +12241,7 @@ export const IDL: Zeta = {
             "type": {
               "array": [
                 "u8",
-                370
+                338
               ]
             }
           }
@@ -14588,6 +14593,11 @@ export const IDL: Zeta = {
       "code": 6128,
       "name": "ForceCancelExpiredTIFOrdersOnly",
       "msg": "Can only force cancel expired TIF orders"
+    },
+    {
+      "code": 6129,
+      "name": "InvalidPlaceOrderAuthority",
+      "msg": "Invalid place order authority"
     }
   ]
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1228,7 +1228,7 @@ export async function pruneExpiredTIFOrders(
     return instructions.pruneExpiredTIFOrdersIx(asset, i);
   });
 
-  let txs = splitIxsIntoTx(ixs, 10);
+  let txs = splitIxsIntoTx(ixs, 5);
 
   await Promise.all(
     txs.map(async (tx) => {


### PR DESCRIPTION
Allow the user to specify a separate pubkey on behalf of which it performs actions - currently only placing and cancelling orders. We can add spread accounts and liquidations later because this is enough for now IMO.