### PR TITLE
Add handy function Exchange.zetaGroupPubkeyToAsset()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+# [0.26.3] 2023-04-11
+
+- exchange: Add handy function Exchange.zetaGroupPubkeyToAsset(). ([#219](https://github.com/zetamarkets/sdk/pull/219))
+
 # [0.26.2] 2023-03-31
 
 - client: Fix cancelAllPerpMarketOrders. ([#217](https://github.com/zetamarkets/sdk/pull/216))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -227,6 +227,13 @@ export class Exchange {
     this._ledgerWallet = wallet;
   }
 
+  // Handy map to grab zetagroup asset by pubkey without an RPC fetch
+  // or having to manually filter all zetaGroups
+  public zetaGroupPubkeyToAsset(key: PublicKey): Asset {
+    return this._zetaGroupPubkeyToAsset.get(key);
+  }
+  private _zetaGroupPubkeyToAsset: Map<PublicKey, Asset> = new Map();
+
   private _useLedger: boolean = false;
 
   private _programSubscriptionIds: number[] = [];
@@ -509,6 +516,10 @@ export class Exchange {
         );
       })
     );
+
+    for (var se of this.getAllSubExchanges()) {
+      this._zetaGroupPubkeyToAsset.set(se.zetaGroupAddress, se.asset);
+    }
 
     this._isInitialized = true;
   }


### PR DESCRIPTION
Store a map to grab zetagroup asset by pubkey without an RPC fetch or having to manually filter all zetaGroups