### PR TITLE
Use confirmTransaction with new args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [0.28.1] 2023-06-07
+
+- utils: use confirmTransaction() with new BlockheightBasedTransactionConfirmationStrategy. ([#235](https://github.com/zetamarkets/sdk/pull/235))
+
 ## [0.28.0] 2023-05-24
 
 - general: Migrate per-asset insurance vault, deposit vault and socialized loss account to be global accounts. ([#230](https://github.com/zetamarkets/sdk/pull/230))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Version changes are pinned to SDK releases.
 
 ## [0.28.1] 2023-06-07
 
-- utils: use confirmTransaction() with new BlockheightBasedTransactionConfirmationStrategy. ([#235](https://github.com/zetamarkets/sdk/pull/235))
+- utils: use confirmTransaction() with new BlockheightBasedTransactionConfirmationStrategy, improving tx timeout detection by specifying the last valid blockheight. ([#235](https://github.com/zetamarkets/sdk/pull/235))
 
 ## [0.28.0] 2023-05-24
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -273,6 +273,8 @@ export class Exchange {
 
   private _programSubscriptionIds: number[] = [];
 
+  private _eventEmitters: any[] = [];
+  
   // Micro lamports per CU of fees.
   public get priorityFee(): number {
     return this._priorityFee;

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,7 +331,7 @@ export interface OrderOptions {
   orderType?: types.OrderType;
   clientOrderId?: number;
   tag?: string;
-  blockhash?: string;
+  blockhash?: { blockhash: string; lastValidBlockHeight: number };
 }
 
 /**


### PR DESCRIPTION
Using `confirmTransaction()` with the new `BlockheightBasedTransactionConfirmationStrategy` provides a better UX in regards to transactions that time out or take a while to confirm. This PR changes that, and there's some extra syntax bits regarding the optional `blockhash` argument