### PR TITLE
Use automatic priority fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
-## [0.29.4] 2023-06-13
+## [0.29.4] 2023-06-15
 
 - exchange: Add functionality to automatically determine priority fees. ([#236](https://github.com/zetamarkets/sdk/pull/236))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [0.28.2] 2023-06-08
+
+- exchange: Add functionality to automatically determine priority fees. ([#236](https://github.com/zetamarkets/sdk/pull/236))
+
 ## [0.28.0] 2023-05-24
 
 - general: Migrate per-asset insurance vault, deposit vault and socialized loss account to be global accounts. ([#230](https://github.com/zetamarkets/sdk/pull/230))

--- a/README.md
+++ b/README.md
@@ -469,14 +469,16 @@ Additional priority fees can be set to maximise your transaction's chance of suc
 ```ts
 // Exchange.load() needs to be called first
 
-let fee = 300; // microlamports per CU
-
-// turn on priority fees for the first time
-Exchange.toggleUsePriorityFees(fee);
-
 // update priority fee amount
 fee = 500;
 Exchange.updatePriorityFee(fee);
+
+// turn off priority fees
+Exchange.updatePriorityFee(0);
+
+// turn on automatic priority fee polling
+// this uses the getRecentPrioritizationFees RPC method
+Exchange.toggleAutoPriorityFee();
 ```
 
 ### Versioned Transactions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "0.28.0",
+  "version": "0.28.2",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -30,7 +30,6 @@ import { Asset } from "./assets";
 import { SubExchange } from "./subexchange";
 import * as instructions from "./program-instructions";
 import { Orderbook } from "./serum/market";
-import fetch from "node-fetch";
 
 export class Exchange {
   /**

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -30,6 +30,7 @@ import { Asset } from "./assets";
 import { SubExchange } from "./subexchange";
 import * as instructions from "./program-instructions";
 import { Orderbook } from "./serum/market";
+import fetch from "node-fetch";
 
 export class Exchange {
   /**
@@ -268,24 +269,18 @@ export class Exchange {
   }
   private _priorityFee: number = 0;
 
-  public get usePriorityFees(): boolean {
-    return this._usePriorityFees;
+  public get useAutoPriorityFee(): boolean {
+    return this._useAutoPriorityFee;
   }
-  private _usePriorityFees: boolean = false;
+  private _useAutoPriorityFee: boolean = false;
 
   public get blockhashCommitment(): Commitment {
     return this._blockhashCommitment;
   }
   private _blockhashCommitment: Commitment = "finalized";
 
-  public toggleUsePriorityFees(
-    microLamportsPerCU: number = constants.DEFAULT_MICRO_LAMPORTS_PER_CU_FEE
-  ) {
-    if (this._usePriorityFees) {
-      throw Error("Priority fees already turned on");
-    }
-    this._usePriorityFees = true;
-    this._priorityFee = microLamportsPerCU;
+  public toggleAutoPriorityFee() {
+    this._useAutoPriorityFee = !this._useAutoPriorityFee;
   }
 
   public updatePriorityFee(microLamportsPerCU: number) {
@@ -617,6 +612,41 @@ export class Exchange {
     return [...this._subExchanges.values()];
   }
 
+  private async updateAutoFee() {
+    let accountList = [];
+
+    // Query the most written-to accounts
+    // Note: getRecentPrioritizationFees() will account for global fees too if no one is writing to our accs
+    for (var asset of this.assets) {
+      let sub = this.getSubExchange(asset);
+      accountList.push(sub.perpSyncQueueAddress.toString());
+      accountList.push(sub.greeksAddress.toString());
+    }
+
+    try {
+      let data = await fetch(this.provider.connection.rpcEndpoint, {
+        method: "post",
+        body: `{"jsonrpc":"2.0", "id":1, "method":"getRecentPrioritizationFees", "params":[["${accountList.join(
+          `","`
+        )}"]]}`,
+        headers: { "Content-Type": "application/json" },
+      });
+
+      let fees = (await data.json()).result
+        .sort((a, b) => b.slot - a.slot) // Sort descending
+        .slice(0, 20) // Grab the latest 20
+        .map((obj) => obj.prioritizationFee); // Take a list of prioritizationFee values only
+
+      let median = utils.median(fees);
+      console.log(
+        `AutoUpdate priority fee. New fee = ${median} microlamports per compute unit`
+      );
+      this._priorityFee = median;
+    } catch (e) {
+      console.log(`updateAutoFee failed ${e}`);
+    }
+  }
+
   private async subscribeOracle(
     assets: Asset[],
     callback?: (asset: Asset, type: EventType, data: any) => void
@@ -672,6 +702,9 @@ export class Exchange {
                 await subExchange.handlePolling(callback);
               })
             );
+            if (this.useAutoPriorityFee == true) {
+              await this.updateAutoFee();
+            }
           }
         } catch (e) {
           console.log(`SubExchange polling failed. Error: ${e}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -753,7 +753,7 @@ export async function processTransaction(
 ): Promise<TransactionSignature> {
   let rawTx: Buffer | Uint8Array;
 
-  if (Exchange.usePriorityFees) {
+  if (Exchange.priorityFee != 0) {
     tx.instructions.unshift(
       ComputeBudgetProgram.setComputeUnitPrice({
         microLamports: Exchange.priorityFee,
@@ -1867,4 +1867,11 @@ export function getUnderlyingMint(asset: assets.Asset) {
 
 export function isFlexUnderlying(asset: assets.Asset) {
   return asset in constants.FLEX_MINTS[Exchange.network];
+}
+
+export function median(arr: number[]): number | undefined {
+  if (!arr.length) return undefined;
+  const s = [...arr].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
 }


### PR DESCRIPTION
Allow the user to toggle on automatic priority fees, which polls getRecentPrioritizationFees() to determine a good fee using a median of the last 20 blocks of fees. Note that we pass in the perpsyncqueue and greeks accounts to the RPC function, as they're the most touched accounts during trading.

We also refactor the existing priority fee logic a bit, removing toggleUsePriorityFees to make things simpler. If you want manual fees, just set Exchange.updatePriorityFee() to be nonzero. If you want automatic fees, just call Exchange.toggleAutoPriorityFee().