### PR TITLE
Force cancel improvements for CrossMarginAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.3.0] 2023-06-30
+
+- Support both marginAccount and crossMarginAccount in forceCancelOrderByOrderId() and forceCancelOrders(). ([#245](https://github.com/zetamarkets/sdk/pull/245))
+
 ## [1.2.0] 2023-06-29
 
 - Improve CrossMarginAccount migration UX. ([#244](https://github.com/zetamarkets/sdk/pull/244))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
-## [1.3.0] 2023-06-30
+## [1.3.1] 2023-06-30
 
 - Support both marginAccount and crossMarginAccount in forceCancelOrderByOrderId() and forceCancelOrders(). ([#245](https://github.com/zetamarkets/sdk/pull/245))
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -616,8 +616,12 @@ export class CrossClient {
     }
   }
 
-  public async findUserMarginAccounts(): Promise<PublicKey[]> {
-    let marginAccounts = [];
+  public async findUserMarginAccounts(): Promise<{
+    addresses: PublicKey[];
+    accounts: programTypes.MarginAccount[];
+  }> {
+    let marginAddresses: PublicKey[] = [];
+    let marginAccounts: programTypes.MarginAccount[] = [];
 
     await Promise.all(
       Exchange.assets.map(async (asset) => {
@@ -630,16 +634,17 @@ export class CrossClient {
 
         // Check if the address is valid
         let account =
-          Exchange.program.account.marginAccount.fetchNullable(address);
+          await Exchange.program.account.marginAccount.fetchNullable(address);
 
         if (account) {
           console.log(`Found ${asset} MarginAccount`);
-          marginAccounts.push(account);
+          marginAddresses.push(address);
+          marginAccounts.push(account as programTypes.MarginAccount);
         }
       })
     );
 
-    return marginAccounts;
+    return { addresses: marginAddresses, accounts: marginAccounts };
   }
 
   public async migrateToCrossMarginAccount(): Promise<TransactionSignature[]> {
@@ -647,7 +652,9 @@ export class CrossClient {
     this.usdcAccountCheck();
 
     // Dynamically figure out the user's existing margin accounts
-    let marginAccounts = await this.findUserMarginAccounts();
+    let accs = await this.findUserMarginAccounts();
+    let marginAddresses = accs.addresses;
+    let marginAccounts = accs.accounts;
 
     let txs = [];
 
@@ -676,18 +683,15 @@ export class CrossClient {
     }
     tx.add(
       instructions.migrateToCrossMarginAccountIx(
-        marginAccounts,
+        marginAddresses,
         this._accountAddress,
         this.publicKey
       )
     );
     txs.push(tx);
 
-    let closeAccs = await Exchange.program.account.marginAccount.fetchMultiple(
-      marginAccounts
-    );
-    for (var i = 0; i < closeAccs.length; i++) {
-      let acc = closeAccs[i] as programTypes.MarginAccount;
+    for (var i = 0; i < marginAccounts.length; i++) {
+      let acc = marginAccounts[i];
       let asset = assets.fromProgramAsset(acc.asset);
       let market = Exchange.getPerpMarket(asset).address;
       const [vaultOwner, _vaultSignerNonce] = utils.getSerumVaultOwnerAndNonce(
@@ -695,27 +699,29 @@ export class CrossClient {
         constants.DEX_PID[Exchange.network]
       );
       tx = new Transaction();
-      tx.add(
-        instructions.settleDexFundsIx(
-          asset,
-          market,
-          vaultOwner,
-          utils.getOpenOrders(Exchange.programId, market, this.publicKey)[0]
-        )
-      );
-      tx.add(
-        instructions.closeOpenOrdersV2Ix(
-          market,
-          this.publicKey,
-          marginAccounts[i],
-          utils.getOpenOrders(Exchange.programId, market, this.publicKey)[0]
-        )
-      );
+      if (acc.openOrdersNonce[constants.PERP_INDEX] != 0) {
+        tx.add(
+          instructions.settleDexFundsIx(
+            asset,
+            market,
+            vaultOwner,
+            utils.getOpenOrders(Exchange.programId, market, this.publicKey)[0]
+          )
+        );
+        tx.add(
+          instructions.closeOpenOrdersV2Ix(
+            market,
+            this.publicKey,
+            marginAddresses[i],
+            utils.getOpenOrders(Exchange.programId, market, this.publicKey)[0]
+          )
+        );
+      }
       tx.add(
         instructions.closeMarginAccountIx(
           asset,
           this.publicKey,
-          marginAccounts[i]
+          marginAddresses[i]
         )
       );
       txs.push(tx);

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -1615,32 +1615,36 @@ export class CrossClient {
   ): Promise<TransactionSignature> {
     this.delegatedCheck();
 
-    let account =
-      await Exchange.program.account.crossMarginAccount.fetchNullable(
-        marginAccountToCancel
-      );
+    let accountInfo = await Exchange.connection.getAccountInfo(
+      marginAccountToCancel
+    );
 
+    let account: programTypes.MarginAccount | programTypes.CrossMarginAccount;
     let openOrdersAccountToCancel: PublicKey;
 
-    // CrossMarginAccount
-    if (account) {
+    try {
+      account =
+        Exchange.program.account.crossMarginAccount.coder.accounts.decode(
+          types.ProgramAccountType.CrossMarginAccount,
+          accountInfo.data
+        ) as programTypes.CrossMarginAccount;
+
       openOrdersAccountToCancel = utils.createCrossOpenOrdersAddress(
         Exchange.programId,
         Exchange.getPerpMarket(asset).address,
         marginAccountToCancel,
         account.openOrdersNonces[assetToIndex(asset)]
       );
-    }
-    // MarginAccount
-    else {
-      let account = await Exchange.program.account.marginAccount.fetchNullable(
-        marginAccountToCancel
-      );
+    } catch (e) {
+      account = Exchange.program.account.marginAccount.coder.accounts.decode(
+        types.ProgramAccountType.MarginAccount,
+        accountInfo.data
+      ) as programTypes.MarginAccount;
       openOrdersAccountToCancel = utils.createOpenOrdersAddress(
         Exchange.programId,
         Exchange.getPerpMarket(asset).address,
         marginAccountToCancel,
-        account.openOrdersNonces[constants.PERP_INDEX]
+        account.openOrdersNonce[constants.PERP_INDEX]
       );
     }
 
@@ -1674,32 +1678,36 @@ export class CrossClient {
   ): Promise<TransactionSignature> {
     this.delegatedCheck();
 
-    let account =
-      await Exchange.program.account.crossMarginAccount.fetchNullable(
-        marginAccountToCancel
-      );
+    let accountInfo = await Exchange.connection.getAccountInfo(
+      marginAccountToCancel
+    );
 
+    let account: programTypes.MarginAccount | programTypes.CrossMarginAccount;
     let openOrdersAccountToCancel: PublicKey;
 
-    // CrossMarginAccount
-    if (account) {
+    try {
+      account =
+        Exchange.program.account.crossMarginAccount.coder.accounts.decode(
+          types.ProgramAccountType.CrossMarginAccount,
+          accountInfo.data
+        ) as programTypes.CrossMarginAccount;
+
       openOrdersAccountToCancel = utils.createCrossOpenOrdersAddress(
         Exchange.programId,
         Exchange.getPerpMarket(asset).address,
         marginAccountToCancel,
         account.openOrdersNonces[assetToIndex(asset)]
       );
-    }
-    // MarginAccount
-    else {
-      let account = await Exchange.program.account.marginAccount.fetchNullable(
-        marginAccountToCancel
-      );
+    } catch (e) {
+      account = Exchange.program.account.marginAccount.coder.accounts.decode(
+        types.ProgramAccountType.MarginAccount,
+        accountInfo.data
+      ) as programTypes.MarginAccount;
       openOrdersAccountToCancel = utils.createOpenOrdersAddress(
         Exchange.programId,
         Exchange.getPerpMarket(asset).address,
         marginAccountToCancel,
-        account.openOrdersNonces[constants.PERP_INDEX]
+        account.openOrdersNonce[constants.PERP_INDEX]
       );
     }
 


### PR DESCRIPTION
Support both `marginAccount` and `crossMarginAccount` in `forceCancelOrderByOrderId()`  and `forceCancelOrders()`