### PR TITLE
Trigger orders (StopLoss/TakeProfit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.8.0] 2023-08-29
+
+- New feature: Trigger Orders. ([#251](https://github.com/zetamarkets/sdk/pull/251))
+
 ## [1.7.4] 2023-08-28
 
 - Clamp executionInfo.size in calculatePnl() instead of throwing and error. ([#261](https://github.com/zetamarkets/sdk/pull/261))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.6.0",
+  "version": "1.8.0",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,6 +99,7 @@ export const CLEAN_MARKET_LIMIT = 9;
 export const CRANK_ACCOUNT_LIMIT = 12;
 export const CRANK_PERP_ACCOUNT_LIMIT = 10;
 export const MAX_MARKETS_TO_FETCH = 50;
+export const MAX_ACCOUNTS_TO_FETCH = 99;
 
 // This is the most we can load per iteration without
 // hitting the rate limit.

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -1155,8 +1155,7 @@ export class CrossClient {
         options.tag,
         this.accountAddress,
         this._provider.wallet.publicKey,
-        openOrdersPda,
-        this._whitelistTradingFeesAddress
+        openOrdersPda
       )
     );
 

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -1151,7 +1151,6 @@ export class CrossClient {
           ? options.orderType
           : types.OrderType.FILLORKILL,
         options.reduceOnly != undefined ? options.reduceOnly : false,
-        options.clientOrderId != undefined ? options.clientOrderId : 0,
         options.tag,
         this.accountAddress,
         this._provider.wallet.publicKey,
@@ -1268,7 +1267,6 @@ export class CrossClient {
           ? newOptions.orderType
           : types.OrderType.FILLORKILL,
         newOptions.reduceOnly != undefined ? newOptions.reduceOnly : false,
-        newOptions.clientOrderId != undefined ? newOptions.clientOrderId : 0,
         this._provider.wallet.publicKey,
         triggerAccount
       )
@@ -2303,9 +2301,6 @@ export class CrossClient {
           ? rawOrder.triggerPrice.toNumber()
           : null,
         size: rawOrder.size.toNumber(),
-        clientOrderId: rawOrder.clientOrderId
-          ? rawOrder.clientOrderId.toNumber()
-          : null,
         creationTs: rawOrder.creationTs.toNumber(),
         triggerDirection: rawOrder.triggerDirection
           ? types.fromProgramTriggerDirection(rawOrder.triggerDirection)
@@ -2315,7 +2310,7 @@ export class CrossClient {
         asset: assets.fromProgramAsset(rawOrder.asset),
         orderType: types.fromProgramOrderType(rawOrder.orderType),
         reduceOnly: rawOrder.reduceOnly,
-        triggerOrderBit: triggerOrderBits[i],
+        triggerOrderBit: rawOrder.bit,
       } as types.TriggerOrder;
 
       triggerOrdersByAsset.get(order.asset).push(order);

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -2322,6 +2322,7 @@ export class CrossClient {
         side: types.fromProgramSide(rawOrder.side),
         asset: assets.fromProgramAsset(rawOrder.asset),
         orderType: types.fromProgramOrderType(rawOrder.orderType),
+        reduceOnly: rawOrder.reduceOnly,
         triggerOrderBit: triggerOrderBits[i],
       } as types.TriggerOrder;
 

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -1100,6 +1100,7 @@ export class CrossClient {
         orderPrice,
         triggerPrice,
         options.triggerDirection,
+        0,
         triggerOrderBit,
         size,
         side,
@@ -1172,6 +1173,7 @@ export class CrossClient {
         newOrderPrice,
         newTriggerPrice,
         newOptions.triggerDirection,
+        0,
         newSize,
         newSide,
         newOptions.orderType != undefined
@@ -2204,13 +2206,20 @@ export class CrossClient {
     triggerOrders.forEach((rawOrder, i) => {
       let order = {
         orderPrice: rawOrder.orderPrice.toNumber(),
-        triggerPrice: rawOrder.triggerPrice.toNumber(),
+        triggerPrice: rawOrder.triggerPrice
+          ? rawOrder.triggerPrice.toNumber()
+          : null,
         size: rawOrder.size.toNumber(),
-        clientOrderId: rawOrder.clientOrderId.toNumber(),
+        clientOrderId: rawOrder.clientOrderId
+          ? rawOrder.clientOrderId.toNumber()
+          : null,
         creationTs: rawOrder.creationTs.toNumber(),
-        triggerDirection: types.fromProgramTriggerDirection(
-          rawOrder.triggerDirection
-        ),
+        triggerDirection: rawOrder.triggerDirection
+          ? types.fromProgramTriggerDirection(rawOrder.triggerDirection)
+          : null,
+        triggerTimestamp: rawOrder.triggerTimestamp
+          ? rawOrder.triggerTimestamp.toNumber()
+          : null,
         side: types.fromProgramSide(rawOrder.side),
         asset: assets.fromProgramAsset(rawOrder.asset),
         orderType: types.fromProgramOrderType(rawOrder.orderType),

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -1101,7 +1101,7 @@ export class CrossClient {
       side,
       triggerPrice,
       triggerDirection,
-      0,
+      new anchor.BN(0),
       options
     );
   }
@@ -1202,7 +1202,27 @@ export class CrossClient {
     );
   }
 
-  public async editTriggerOrder(
+  public async editTimestampTriggerOrder(
+    orderIndex: number,
+    newOrderPrice: number,
+    newTriggerTime: anchor.BN,
+    newSize: number,
+    newSide: types.Side,
+    newOptions: types.TriggerOrderOptions = types.defaultTriggerOrderOptions()
+  ) {
+    await this.editTriggerOrder(
+      orderIndex,
+      newOrderPrice,
+      newSize,
+      newSide,
+      0,
+      types.TriggerDirection.UNINITIALIZED,
+      newTriggerTime,
+      newOptions
+    );
+  }
+
+  public async editPriceTriggerOrder(
     orderIndex: number,
     newOrderPrice: number,
     newTriggerPrice: number,
@@ -1212,6 +1232,30 @@ export class CrossClient {
     newDirection: types.TriggerDirection = types.getDefaultTriggerDirection(
       newSide
     )
+  ) {
+    await this.editTriggerOrder(
+      orderIndex,
+      newOrderPrice,
+      newSize,
+      newSide,
+      newTriggerPrice,
+      newDirection,
+      new anchor.BN(0),
+      newOptions
+    );
+  }
+
+  private async editTriggerOrder(
+    orderIndex: number,
+    newOrderPrice: number,
+    newSize: number,
+    newSide: types.Side,
+    newTriggerPrice: number,
+    newDirection: types.TriggerDirection = types.getDefaultTriggerDirection(
+      newSide
+    ),
+    newTriggerTimestamp: anchor.BN,
+    newOptions: types.TriggerOrderOptions = types.defaultTriggerOrderOptions()
   ) {
     let triggerAccount = utils.getTriggerOrder(
       Exchange.programId,
@@ -1223,7 +1267,7 @@ export class CrossClient {
         newOrderPrice,
         newTriggerPrice,
         newDirection,
-        0,
+        newTriggerTimestamp,
         newSize,
         newSide,
         newOptions.orderType != undefined
@@ -2267,9 +2311,7 @@ export class CrossClient {
         triggerDirection: rawOrder.triggerDirection
           ? types.fromProgramTriggerDirection(rawOrder.triggerDirection)
           : null,
-        triggerTimestamp: rawOrder.triggerTimestamp
-          ? rawOrder.triggerTimestamp.toNumber()
-          : null,
+        triggerTimestamp: rawOrder.triggerTs ? rawOrder.triggerTs : null,
         side: types.fromProgramSide(rawOrder.side),
         asset: assets.fromProgramAsset(rawOrder.asset),
         orderType: types.fromProgramOrderType(rawOrder.orderType),

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -1019,7 +1019,7 @@ export class CrossClient {
 
     let tifOffsetToUse = utils.getTIFOffset(market, options.tifOptions);
 
-    let orderIx = instructions.placePerpOrderV3Ix(
+    let orderIx = instructions.placePerpOrderV4Ix(
       asset,
       price,
       size,
@@ -1027,6 +1027,7 @@ export class CrossClient {
       options.orderType != undefined
         ? options.orderType
         : types.OrderType.LIMIT,
+      options.reduceOnly != undefined ? options.reduceOnly : false,
       options.clientOrderId != undefined ? options.clientOrderId : 0,
       options.tag != undefined ? options.tag : constants.DEFAULT_ORDER_TAG,
       tifOffsetToUse,
@@ -1156,6 +1157,7 @@ export class CrossClient {
         options.orderType != undefined
           ? options.orderType
           : types.OrderType.FILLORKILL,
+        options.reduceOnly != undefined ? options.reduceOnly : false,
         options.clientOrderId != undefined ? options.clientOrderId : 0,
         options.tag,
         this.accountAddress,
@@ -1273,6 +1275,7 @@ export class CrossClient {
         newOptions.orderType != undefined
           ? newOptions.orderType
           : types.OrderType.FILLORKILL,
+        newOptions.reduceOnly != undefined ? newOptions.reduceOnly : false,
         newOptions.clientOrderId != undefined ? newOptions.clientOrderId : 0,
         this._provider.wallet.publicKey,
         triggerAccount
@@ -1471,7 +1474,7 @@ export class CrossClient {
     let market = Exchange.getPerpMarket(asset);
     let tifOffset = utils.getTIFOffset(market, options.tifOptions);
 
-    return instructions.placePerpOrderV3Ix(
+    return instructions.placePerpOrderV4Ix(
       asset,
       price,
       size,
@@ -1479,6 +1482,7 @@ export class CrossClient {
       options.orderType != undefined
         ? options.orderType
         : types.OrderType.LIMIT,
+      options.reduceOnly != undefined ? options.reduceOnly : false,
       options.clientOrderId != undefined ? options.clientOrderId : 0,
       options.tag != undefined ? options.tag : constants.DEFAULT_ORDER_TAG,
       tifOffset,
@@ -1590,7 +1594,7 @@ export class CrossClient {
     let tifOffsetToUse = utils.getTIFOffset(market, options.tifOptions);
 
     tx.add(
-      instructions.placePerpOrderV3Ix(
+      instructions.placePerpOrderV4Ix(
         asset,
         newOrderPrice,
         newOrderSize,
@@ -1598,6 +1602,7 @@ export class CrossClient {
         options.orderType != undefined
           ? options.orderType
           : types.OrderType.LIMIT,
+        options.reduceOnly != undefined ? options.reduceOnly : false,
         options.clientOrderId != undefined ? options.clientOrderId : 0,
         options.tag != undefined ? options.tag : constants.DEFAULT_ORDER_TAG,
         tifOffsetToUse,
@@ -1654,7 +1659,7 @@ export class CrossClient {
     let tifOffsetToUse = utils.getTIFOffset(market, newOptions.tifOptions);
 
     tx.add(
-      instructions.placePerpOrderV3Ix(
+      instructions.placePerpOrderV4Ix(
         asset,
         newOrderPrice,
         newOrderSize,
@@ -1662,6 +1667,7 @@ export class CrossClient {
         newOptions.orderType != undefined
           ? newOptions.orderType
           : types.OrderType.LIMIT,
+        newOptions.reduceOnly != undefined ? newOptions.reduceOnly : false,
         newOptions.clientOrderId != undefined ? newOptions.clientOrderId : 0,
         newOptions.tag != undefined
           ? newOptions.tag
@@ -1721,7 +1727,7 @@ export class CrossClient {
     let tifOffsetToUse = utils.getTIFOffset(market, newOptions.tifOptions);
 
     tx.add(
-      instructions.placePerpOrderV3Ix(
+      instructions.placePerpOrderV4Ix(
         asset,
         newOrderPrice,
         newOrderSize,
@@ -1729,6 +1735,7 @@ export class CrossClient {
         newOptions.orderType != undefined
           ? newOptions.orderType
           : types.OrderType.LIMIT,
+        newOptions.reduceOnly != undefined ? newOptions.reduceOnly : false,
         newOptions.clientOrderId != undefined ? newOptions.clientOrderId : 0,
         newOptions.tag != undefined
           ? newOptions.tag

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -1089,6 +1089,26 @@ export class Exchange {
     }
   }
 
+  public async adminCancelTriggerOrder(
+    orderIndex: number,
+    crossMarginAccount: PublicKey
+  ) {
+    let triggerAccount = utils.getTriggerOrder(
+      this.programId,
+      crossMarginAccount,
+      new Uint8Array([orderIndex])
+    )[0];
+    let tx = new Transaction().add(
+      instructions.cancelTriggerOrderIx(
+        orderIndex,
+        this._provider.wallet.publicKey,
+        triggerAccount,
+        crossMarginAccount
+      )
+    );
+    return await utils.processTransaction(this._provider, tx);
+  }
+
   public updateMarginParams(asset: Asset) {
     this.getSubExchange(asset).updateMarginParams();
   }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -9884,8 +9884,8 @@
     },
     {
       "code": 6152,
-      "name": "InvalidTriggerOrderBit",
-      "msg": "Invalid trigger order index"
+      "name": "InvalidTriggerOrderBitRange",
+      "msg": "Invalid trigger order bit range"
     },
     {
       "code": 6153,
@@ -9901,6 +9901,11 @@
       "code": 6155,
       "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
       "msg": "Trigger order needs either a trigger price + direction, or trigger time"
+    },
+    {
+      "code": 6156,
+      "name": "TriggerOrderBitOccupied",
+      "msg": "Given trigger order bit is occupied, pick another"
     }
   ]
 }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -3966,7 +3966,7 @@
           "isSigner": false
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -3988,7 +3988,7 @@
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         },
         {
@@ -4050,7 +4050,7 @@
           "isSigner": false
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -4187,7 +4187,7 @@
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         }
       ]
@@ -4211,7 +4211,7 @@
           "isSigner": true
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -4223,7 +4223,7 @@
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         }
       ]
@@ -4237,7 +4237,7 @@
           "isSigner": true
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         }
@@ -6980,7 +6980,7 @@
             }
           },
           {
-            "name": "triggerOrderIndexes",
+            "name": "triggerOrderBits",
             "type": "u128"
           },
           {
@@ -7105,7 +7105,7 @@
       }
     },
     {
-      "name": "TriggerOrderInfo",
+      "name": "TriggerOrder",
       "type": {
         "kind": "struct",
         "fields": [
@@ -9852,13 +9852,18 @@
     },
     {
       "code": 6152,
-      "name": "InvalidTriggerOrderIndex",
+      "name": "InvalidTriggerOrderBit",
       "msg": "Invalid trigger order index"
     },
     {
       "code": 6153,
       "name": "InvalidSecondaryAdmin",
       "msg": "Invalid secondary admin"
+    },
+    {
+      "code": 6154,
+      "name": "OnlyOwnerCanEditTriggerOrder",
+      "msg": "Only the owner can edit their own trigger order"
     }
   ]
 }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -3938,6 +3938,196 @@
       ]
     },
     {
+      "name": "placePerpOrderV4",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "placeOrderAccounts",
+          "accounts": [
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pricing",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "rent",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketAccounts",
+              "accounts": [
+                {
+                  "name": "market",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "requestQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "eventQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "bids",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "asks",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "orderPayerTokenAccount",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinWallet",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcWallet",
+                  "isMut": true,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "oracle",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupFeed",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mintAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "perpSyncQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "price",
+          "type": "u64"
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "tag",
+          "type": {
+            "option": "string"
+          }
+        },
+        {
+          "name": "tifOffset",
+          "type": {
+            "option": "u16"
+          }
+        },
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
+    },
+    {
       "name": "placeTriggerOrder",
       "accounts": [
         {
@@ -4030,6 +4220,10 @@
           "type": {
             "defined": "OrderType"
           }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
         },
         {
           "name": "clientOrderId",
@@ -4292,6 +4486,10 @@
           "type": {
             "defined": "OrderType"
           }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
         },
         {
           "name": "clientOrderId",
@@ -7200,6 +7398,10 @@
             "type": {
               "defined": "OrderType"
             }
+          },
+          {
+            "name": "reduceOnly",
+            "type": "bool"
           }
         ]
       }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -4226,12 +4226,6 @@
           "type": "bool"
         },
         {
-          "name": "clientOrderId",
-          "type": {
-            "option": "u64"
-          }
-        },
-        {
           "name": "tag",
           "type": {
             "option": "string"
@@ -4490,12 +4484,6 @@
         {
           "name": "reduceOnly",
           "type": "bool"
-        },
-        {
-          "name": "clientOrderId",
-          "type": {
-            "option": "u64"
-          }
         }
       ]
     },
@@ -6723,15 +6711,11 @@
             }
           },
           {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
-          },
-          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                334
+                338
               ]
             }
           }
@@ -7360,12 +7344,6 @@
             "type": "u64"
           },
           {
-            "name": "clientOrderId",
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
             "name": "creationTs",
             "type": "u64"
           },
@@ -7394,6 +7372,10 @@
             "type": {
               "defined": "OrderType"
             }
+          },
+          {
+            "name": "bit",
+            "type": "u8"
           },
           {
             "name": "reduceOnly",
@@ -8212,10 +8194,6 @@
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
-          },
-          {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
           }
         ]
       }
@@ -8328,10 +8306,6 @@
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
-          },
-          {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
           }
         ]
       }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -8544,10 +8544,10 @@
             "name": "Uninitialized"
           },
           {
-            "name": "Increasing"
+            "name": "LessThanOrEqual"
           },
           {
-            "name": "Decreasing"
+            "name": "GreaterThanOrEqual"
           }
         ]
       }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -3938,6 +3938,350 @@
       ]
     },
     {
+      "name": "placeTriggerOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "openOrders",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "pricing",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "dexProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "market",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        },
+        {
+          "name": "orderPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerDirection",
+          "type": {
+            "defined": "TriggerDirection"
+          }
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "tag",
+          "type": {
+            "option": "string"
+          }
+        },
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
+    },
+    {
+      "name": "executeTriggerOrder",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "placeOrderAccounts",
+          "accounts": [
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pricing",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "rent",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketAccounts",
+              "accounts": [
+                {
+                  "name": "market",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "requestQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "eventQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "bids",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "asks",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "orderPayerTokenAccount",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinWallet",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcWallet",
+                  "isMut": true,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "oracle",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupFeed",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mintAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "perpSyncQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "cancelTriggerOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "editTriggerOrder",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerDirection",
+          "type": {
+            "defined": "TriggerDirection"
+          }
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
       "name": "cancelOrder",
       "accounts": [
         {
@@ -6161,11 +6505,15 @@
             }
           },
           {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                338
+                334
               ]
             }
           }
@@ -6632,11 +6980,15 @@
             }
           },
           {
+            "name": "triggerOrderIndexes",
+            "type": "u128"
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                2000
+                1984
               ]
             }
           }
@@ -6747,6 +7099,74 @@
                 "u8",
                 338
               ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerOrderInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "marginAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "openOrders",
+            "type": "publicKey"
+          },
+          {
+            "name": "whitelistTradingFeesAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "orderPrice",
+            "type": "u64"
+          },
+          {
+            "name": "triggerPrice",
+            "type": "u64"
+          },
+          {
+            "name": "size",
+            "type": "u64"
+          },
+          {
+            "name": "clientOrderId",
+            "type": "u64"
+          },
+          {
+            "name": "creationTs",
+            "type": "u64"
+          },
+          {
+            "name": "triggerDirection",
+            "type": {
+              "defined": "TriggerDirection"
+            }
+          },
+          {
+            "name": "side",
+            "type": {
+              "defined": "Side"
+            }
+          },
+          {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
+            "name": "orderType",
+            "type": {
+              "defined": "OrderType"
             }
           }
         ]
@@ -7562,6 +7982,10 @@
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
+          },
+          {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
           }
         ]
       }
@@ -7674,6 +8098,10 @@
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
+          },
+          {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
           }
         ]
       }
@@ -8103,6 +8531,23 @@
           },
           {
             "name": "Ask"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Uninitialized"
+          },
+          {
+            "name": "Increasing"
+          },
+          {
+            "name": "Decreasing"
           }
         ]
       }
@@ -9369,6 +9814,51 @@
       "code": 6144,
       "name": "MarginAccountCannotLiquidateCrossMarginAccount",
       "msg": "MarginAccount cannot liquidate CrossMarginAccount"
+    },
+    {
+      "code": 6145,
+      "name": "TriggerOrderCannotBeRemoved",
+      "msg": "Trigger order cannot be removed"
+    },
+    {
+      "code": 6146,
+      "name": "TriggerOrderCannotBeExecuted",
+      "msg": "Trigger order cannot be executed"
+    },
+    {
+      "code": 6147,
+      "name": "TriggerOrderOnlySupportsCrossMarginAccounts",
+      "msg": "Trigger order only supports CrossMarginAccounts"
+    },
+    {
+      "code": 6148,
+      "name": "TooManyTriggerOrders",
+      "msg": "Too many trigger orders, close some and retry"
+    },
+    {
+      "code": 6149,
+      "name": "InvalidTriggerOrderRemainingAccounts",
+      "msg": "Invalid trigger order remaining accounts"
+    },
+    {
+      "code": 6150,
+      "name": "InvalidTriggerOrderWhitelistFeesAccount",
+      "msg": "Invalid trigger order whitelist fees account"
+    },
+    {
+      "code": 6151,
+      "name": "MissingTriggerOrderWhitelistFeesAccount",
+      "msg": "Missing trigger order whitelist fees account"
+    },
+    {
+      "code": 6152,
+      "name": "InvalidTriggerOrderIndex",
+      "msg": "Invalid trigger order index"
+    },
+    {
+      "code": 6153,
+      "name": "InvalidSecondaryAdmin",
+      "msg": "Invalid secondary admin"
     }
   ]
 }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -3997,12 +3997,22 @@
         },
         {
           "name": "triggerPrice",
-          "type": "u64"
+          "type": {
+            "option": "u64"
+          }
         },
         {
           "name": "triggerDirection",
           "type": {
-            "defined": "TriggerDirection"
+            "option": {
+              "defined": "TriggerDirection"
+            }
+          }
+        },
+        {
+          "name": "triggerTs",
+          "type": {
+            "option": "u64"
           }
         },
         {
@@ -4249,12 +4259,22 @@
         },
         {
           "name": "triggerPrice",
-          "type": "u64"
+          "type": {
+            "option": "u64"
+          }
         },
         {
           "name": "triggerDirection",
           "type": {
-            "defined": "TriggerDirection"
+            "option": {
+              "defined": "TriggerDirection"
+            }
+          }
+        },
+        {
+          "name": "triggerTs",
+          "type": {
+            "option": "u64"
           }
         },
         {
@@ -7131,7 +7151,15 @@
           },
           {
             "name": "triggerPrice",
-            "type": "u64"
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "triggerTs",
+            "type": {
+              "option": "u64"
+            }
           },
           {
             "name": "size",
@@ -7139,7 +7167,9 @@
           },
           {
             "name": "clientOrderId",
-            "type": "u64"
+            "type": {
+              "option": "u64"
+            }
           },
           {
             "name": "creationTs",
@@ -7148,7 +7178,9 @@
           {
             "name": "triggerDirection",
             "type": {
-              "defined": "TriggerDirection"
+              "option": {
+                "defined": "TriggerDirection"
+              }
             }
           },
           {
@@ -9864,6 +9896,11 @@
       "code": 6154,
       "name": "OnlyOwnerCanEditTriggerOrder",
       "msg": "Only the owner can edit their own trigger order"
+    },
+    {
+      "code": 6155,
+      "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
+      "msg": "Trigger order needs either a trigger price + direction, or trigger time"
     }
   ]
 }

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -7340,10 +7340,6 @@
             "type": "publicKey"
           },
           {
-            "name": "whitelistTradingFeesAccount",
-            "type": "publicKey"
-          },
-          {
             "name": "orderPrice",
             "type": "u64"
           },
@@ -10071,51 +10067,46 @@
     },
     {
       "code": 6148,
-      "name": "TriggerOrderOnlySupportsCrossMarginAccounts",
-      "msg": "Trigger order only supports CrossMarginAccounts"
-    },
-    {
-      "code": 6149,
       "name": "TooManyTriggerOrders",
       "msg": "Too many trigger orders, close some and retry"
     },
     {
-      "code": 6150,
+      "code": 6149,
       "name": "InvalidTriggerOrderRemainingAccounts",
       "msg": "Invalid trigger order remaining accounts"
     },
     {
-      "code": 6151,
+      "code": 6150,
       "name": "InvalidTriggerOrderWhitelistFeesAccount",
       "msg": "Invalid trigger order whitelist fees account"
     },
     {
-      "code": 6152,
+      "code": 6151,
       "name": "MissingTriggerOrderWhitelistFeesAccount",
       "msg": "Missing trigger order whitelist fees account"
     },
     {
-      "code": 6153,
+      "code": 6152,
       "name": "InvalidTriggerOrderBitRange",
       "msg": "Invalid trigger order bit range"
     },
     {
-      "code": 6154,
+      "code": 6153,
       "name": "InvalidSecondaryAdmin",
       "msg": "Invalid secondary admin"
     },
     {
-      "code": 6155,
+      "code": 6154,
       "name": "OnlyOwnerCanEditTriggerOrder",
       "msg": "Only the owner can edit their own trigger order"
     },
     {
-      "code": 6156,
+      "code": 6155,
       "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
       "msg": "Trigger order needs either a trigger price + direction, or trigger time"
     },
     {
-      "code": 6157,
+      "code": 6156,
       "name": "TriggerOrderBitOccupied",
       "msg": "Given trigger order bit is occupied, pick another"
     }

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -543,25 +543,13 @@ export function placeTriggerOrderIx(
   tag: String,
   marginAccount: PublicKey,
   authority: PublicKey,
-  openOrders: PublicKey,
-  whitelistTradingFeesAccount: PublicKey | undefined
+  openOrders: PublicKey
 ): TransactionInstruction {
   let [triggerOrder, _nonce] = utils.getTriggerOrder(
     Exchange.programId,
     marginAccount,
     Uint8Array.from([triggerOrderBit])
   );
-
-  let remainingAccounts =
-    whitelistTradingFeesAccount !== undefined
-      ? [
-          {
-            pubkey: whitelistTradingFeesAccount,
-            isSigner: false,
-            isWritable: false,
-          },
-        ]
-      : [];
   return Exchange.program.instruction.placeTriggerOrder(
     triggerOrderBit,
     new anchor.BN(orderPrice),
@@ -589,7 +577,6 @@ export function placeTriggerOrderIx(
         dexProgram: constants.DEX_PID[Exchange.network],
         market: Exchange.getPerpMarket(asset).serumMarket.address,
       },
-      remainingAccounts,
     }
   );
 }
@@ -599,20 +586,9 @@ export function executeTriggerOrderIx(
   triggerOrderBit: number,
   triggerOrder: PublicKey,
   marginAccount: PublicKey,
-  openOrders: PublicKey,
-  whitelistTradingFeesAccount: PublicKey | undefined
+  openOrders: PublicKey
 ): TransactionInstruction {
   let marketData = Exchange.getPerpMarket(asset);
-  let remainingAccounts =
-    whitelistTradingFeesAccount !== undefined
-      ? [
-          {
-            pubkey: whitelistTradingFeesAccount,
-            isSigner: false,
-            isWritable: false,
-          },
-        ]
-      : [];
 
   return Exchange.program.instruction.executeTriggerOrder(triggerOrderBit, {
     accounts: {
@@ -655,7 +631,6 @@ export function executeTriggerOrderIx(
         perpSyncQueue: Exchange.pricing.perpSyncQueues[assetToIndex(asset)],
       },
     },
-    remainingAccounts,
   });
 }
 export function cancelTriggerOrderIx(

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -529,7 +529,7 @@ export function placeTriggerOrderIx(
   orderPrice: number,
   triggerPrice: number,
   triggerDirection: types.TriggerDirection,
-  triggerOrderIndex: number,
+  triggerOrderBit: number,
   size: number,
   side: types.Side,
   orderType: types.OrderType,
@@ -540,10 +540,10 @@ export function placeTriggerOrderIx(
   openOrders: PublicKey,
   whitelistTradingFeesAccount: PublicKey | undefined
 ): TransactionInstruction {
-  let [triggerOrderInfo, _nonce] = utils.getTriggerOrderInfo(
+  let [triggerOrder, _nonce] = utils.getTriggerOrder(
     Exchange.programId,
     marginAccount,
-    Uint8Array.from([triggerOrderIndex])
+    Uint8Array.from([triggerOrderBit])
   );
 
   let remainingAccounts =
@@ -557,7 +557,7 @@ export function placeTriggerOrderIx(
         ]
       : [];
   return Exchange.program.instruction.placeTriggerOrder(
-    triggerOrderIndex,
+    triggerOrderBit,
     new anchor.BN(orderPrice),
     new anchor.BN(triggerPrice),
     types.toProgramTriggerDirection(triggerDirection),
@@ -574,7 +574,7 @@ export function placeTriggerOrderIx(
         authority: authority,
         marginAccount: marginAccount,
         pricing: Exchange.pricingAddress,
-        triggerOrderInfo: triggerOrderInfo,
+        triggerOrder: triggerOrder,
         systemProgram: SystemProgram.programId,
         dexProgram: constants.DEX_PID[Exchange.network],
         market: Exchange.getPerpMarket(asset).serumMarket.address,
@@ -586,8 +586,8 @@ export function placeTriggerOrderIx(
 export function executeTriggerOrderIx(
   asset: Asset,
   side: types.Side,
-  triggerOrderIndex: number,
-  triggerOrderInfo: PublicKey,
+  triggerOrderBit: number,
+  triggerOrder: PublicKey,
   marginAccount: PublicKey,
   openOrders: PublicKey,
   whitelistTradingFeesAccount: PublicKey | undefined
@@ -604,10 +604,10 @@ export function executeTriggerOrderIx(
         ]
       : [];
 
-  return Exchange.program.instruction.executeTriggerOrder(triggerOrderIndex, {
+  return Exchange.program.instruction.executeTriggerOrder(triggerOrderBit, {
     accounts: {
       admin: Exchange.state.secondaryAdmin,
-      triggerOrderInfo: triggerOrderInfo,
+      triggerOrder: triggerOrder,
       placeOrderAccounts: {
         state: Exchange.stateAddress,
         pricing: Exchange.pricingAddress,
@@ -649,17 +649,17 @@ export function executeTriggerOrderIx(
   });
 }
 export function cancelTriggerOrderIx(
-  triggerOrderIndex: number,
+  triggerOrderBit: number,
   payer: PublicKey,
-  triggerOrderInfo: PublicKey,
+  triggerOrder: PublicKey,
   marginAccount: PublicKey
 ): TransactionInstruction {
-  return Exchange.program.instruction.cancelTriggerOrder(triggerOrderIndex, {
+  return Exchange.program.instruction.cancelTriggerOrder(triggerOrderBit, {
     accounts: {
       state: Exchange.stateAddress,
       payer: payer,
       admin: Exchange.state.secondaryAdmin,
-      triggerOrderInfo: triggerOrderInfo,
+      triggerOrder: triggerOrder,
       marginAccount: marginAccount,
     },
   });
@@ -673,7 +673,7 @@ export function editTriggerOrderIx(
   newOrderType: types.OrderType,
   newClientOrderId: number,
   owner: PublicKey,
-  triggerOrderInfo: PublicKey
+  triggerOrder: PublicKey
 ): TransactionInstruction {
   return Exchange.program.instruction.editTriggerOrder(
     new anchor.BN(newOrderPrice),
@@ -686,7 +686,7 @@ export function editTriggerOrderIx(
     {
       accounts: {
         owner: owner,
-        triggerOrderInfo: triggerOrderInfo,
+        triggerOrder: triggerOrder,
       },
     }
   );

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -529,6 +529,7 @@ export function placeTriggerOrderIx(
   orderPrice: number,
   triggerPrice: number,
   triggerDirection: types.TriggerDirection,
+  triggerTimestamp: number,
   triggerOrderBit: number,
   size: number,
   side: types.Side,
@@ -559,8 +560,11 @@ export function placeTriggerOrderIx(
   return Exchange.program.instruction.placeTriggerOrder(
     triggerOrderBit,
     new anchor.BN(orderPrice),
-    new anchor.BN(triggerPrice),
-    types.toProgramTriggerDirection(triggerDirection),
+    triggerPrice == 0 ? null : new anchor.BN(triggerPrice),
+    triggerDirection == types.TriggerDirection.UNINITIALIZED
+      ? null
+      : types.toProgramTriggerDirection(triggerDirection),
+    triggerTimestamp == 0 ? null : new anchor.BN(triggerTimestamp),
     new anchor.BN(size),
     types.toProgramSide(side),
     types.toProgramOrderType(orderType),
@@ -668,6 +672,7 @@ export function editTriggerOrderIx(
   newOrderPrice: number,
   newTriggerPrice: number,
   newTriggerDirection: types.TriggerDirection,
+  newTriggerTimestamp: number,
   newSize: number,
   newSide: types.Side,
   newOrderType: types.OrderType,
@@ -677,8 +682,11 @@ export function editTriggerOrderIx(
 ): TransactionInstruction {
   return Exchange.program.instruction.editTriggerOrder(
     new anchor.BN(newOrderPrice),
-    new anchor.BN(newTriggerPrice),
-    types.toProgramTriggerDirection(newTriggerDirection),
+    newTriggerPrice == 0 ? null : new anchor.BN(newTriggerPrice),
+    newTriggerDirection == types.TriggerDirection.UNINITIALIZED
+      ? null
+      : types.toProgramTriggerDirection(newTriggerDirection),
+    newTriggerTimestamp == 0 ? null : new anchor.BN(newTriggerTimestamp),
     new anchor.BN(newSize),
     types.toProgramSide(newSide),
     types.toProgramOrderType(newOrderType),

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -672,7 +672,7 @@ export function editTriggerOrderIx(
   newOrderPrice: number,
   newTriggerPrice: number,
   newTriggerDirection: types.TriggerDirection,
-  newTriggerTimestamp: number,
+  newTriggerTimestamp: anchor.BN,
   newSize: number,
   newSide: types.Side,
   newOrderType: types.OrderType,

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -539,7 +539,6 @@ export function placeTriggerOrderIx(
   side: types.Side,
   orderType: types.OrderType,
   reduceOnly: boolean,
-  clientOrderId: number,
   tag: String,
   marginAccount: PublicKey,
   authority: PublicKey,
@@ -562,7 +561,6 @@ export function placeTriggerOrderIx(
     types.toProgramSide(side),
     types.toProgramOrderType(orderType),
     reduceOnly,
-    clientOrderId == 0 ? null : new anchor.BN(clientOrderId),
     new String(tag),
     toProgramAsset(asset),
     {
@@ -658,7 +656,6 @@ export function editTriggerOrderIx(
   newSide: types.Side,
   newOrderType: types.OrderType,
   newReduceOnly: boolean,
-  newClientOrderId: number,
   owner: PublicKey,
   triggerOrder: PublicKey
 ): TransactionInstruction {
@@ -673,7 +670,6 @@ export function editTriggerOrderIx(
     types.toProgramSide(newSide),
     types.toProgramOrderType(newOrderType),
     newReduceOnly,
-    newClientOrderId == 0 ? null : new anchor.BN(newClientOrderId),
     {
       accounts: {
         owner: owner,
@@ -2219,7 +2215,6 @@ export interface StateParams {
   nativeWithdrawLimit: anchor.BN;
   withdrawLimitEpochSeconds: number;
   nativeOpenInterestLimit: anchor.BN;
-  triggerOrderTimeoutSeconds: number;
 }
 
 export interface UpdatePricingParametersArgs {

--- a/src/program-instructions.ts
+++ b/src/program-instructions.ts
@@ -529,7 +529,7 @@ export function placeTriggerOrderIx(
   orderPrice: number,
   triggerPrice: number,
   triggerDirection: types.TriggerDirection,
-  triggerTimestamp: number,
+  triggerTimestamp: anchor.BN,
   triggerOrderBit: number,
   size: number,
   side: types.Side,
@@ -564,7 +564,7 @@ export function placeTriggerOrderIx(
     triggerDirection == types.TriggerDirection.UNINITIALIZED
       ? null
       : types.toProgramTriggerDirection(triggerDirection),
-    triggerTimestamp == 0 ? null : new anchor.BN(triggerTimestamp),
+    triggerTimestamp == 0 ? null : triggerTimestamp,
     new anchor.BN(size),
     types.toProgramSide(side),
     types.toProgramOrderType(orderType),

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -242,11 +242,12 @@ export interface TriggerOrder {
   openOrders: PublicKey;
   whitelistTradingFeesAccount: PublicKey;
   orderPrice: anchor.BN;
-  triggerPrice: anchor.BN;
+  triggerPrice: anchor.BN | null; // Option<u64>
+  triggerTs: anchor.BN | null; // Option<u64>
   size: anchor.BN;
-  clientOrderId: anchor.BN;
+  clientOrderId: anchor.BN | null; // Option<u64>
   creationTs: anchor.BN;
-  triggerDirection: any; // enum TriggerDirection
+  triggerDirection: any | null; // Option<TriggerDirection>
   side: any; // enum Side
   asset: any; // enum Asset
   orderType: any; // enum OrderType

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -202,7 +202,7 @@ export interface CrossMarginAccount {
   lastFundingDeltasPadding: Array<AnchorDecimal>;
   productLedgers: Array<ProductLedger>;
   productLedgersPadding: Array<ProductLedger>;
-  triggerOrderIndexes: anchor.BN;
+  triggerOrderBits: anchor.BN;
   padding: Array<number>;
 }
 
@@ -236,7 +236,7 @@ export interface SpreadAccount {
   padding: Array<number>;
 }
 
-export interface TriggerOrderInfo {
+export interface TriggerOrder {
   owner: PublicKey;
   marginAccount: PublicKey;
   openOrders: PublicKey;

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -36,7 +36,6 @@ export interface State {
   nativeOpenInterestLimit: anchor.BN;
   haltStates: Array<HaltStateV2>;
   haltStatesPadding: Array<HaltStateV2>;
-  triggerOrderTimeoutSeconds: number;
   padding: Array<number>;
 }
 
@@ -244,12 +243,12 @@ export interface TriggerOrder {
   triggerPrice: anchor.BN | null; // Option<u64>
   triggerTs: anchor.BN | null; // Option<u64>
   size: anchor.BN;
-  clientOrderId: anchor.BN | null; // Option<u64>
   creationTs: anchor.BN;
   triggerDirection: any | null; // Option<TriggerDirection>
   side: any; // enum Side
   asset: any; // enum Asset
   orderType: any; // enum OrderType
+  bit: number;
   reduceOnly: boolean;
 }
 

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -36,6 +36,7 @@ export interface State {
   nativeOpenInterestLimit: anchor.BN;
   haltStates: Array<HaltStateV2>;
   haltStatesPadding: Array<HaltStateV2>;
+  triggerOrderTimeoutSeconds: number;
   padding: Array<number>;
 }
 
@@ -201,6 +202,7 @@ export interface CrossMarginAccount {
   lastFundingDeltasPadding: Array<AnchorDecimal>;
   productLedgers: Array<ProductLedger>;
   productLedgersPadding: Array<ProductLedger>;
+  triggerOrderIndexes: anchor.BN;
   padding: Array<number>;
 }
 
@@ -232,6 +234,22 @@ export interface SpreadAccount {
   positionsPadding: Array<Position>;
   asset: any;
   padding: Array<number>;
+}
+
+export interface TriggerOrderInfo {
+  owner: PublicKey;
+  marginAccount: PublicKey;
+  openOrders: PublicKey;
+  whitelistTradingFeesAccount: PublicKey;
+  orderPrice: anchor.BN;
+  triggerPrice: anchor.BN;
+  size: anchor.BN;
+  clientOrderId: anchor.BN;
+  creationTs: anchor.BN;
+  triggerDirection: any; // enum TriggerDirection
+  side: any; // enum Side
+  asset: any; // enum Asset
+  orderType: any; // enum OrderType
 }
 
 export interface PerpSyncQueue {

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -240,7 +240,6 @@ export interface TriggerOrder {
   owner: PublicKey;
   marginAccount: PublicKey;
   openOrders: PublicKey;
-  whitelistTradingFeesAccount: PublicKey;
   orderPrice: anchor.BN;
   triggerPrice: anchor.BN | null; // Option<u64>
   triggerTs: anchor.BN | null; // Option<u64>

--- a/src/program-types.ts
+++ b/src/program-types.ts
@@ -251,6 +251,7 @@ export interface TriggerOrder {
   side: any; // enum Side
   asset: any; // enum Asset
   orderType: any; // enum OrderType
+  reduceOnly: boolean;
 }
 
 export interface PerpSyncQueue {

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -622,7 +622,7 @@ export class RiskCalculator {
     let availableBalanceInitial: number =
       balance + upnlTotal + unpaidFundingTotal - imTotal;
     let availableBalanceWithdrawable: number =
-      balance + upnlTotal + unpaidFundingTotal;
+      balance + upnlTotal + unpaidFundingTotal - imSkipConcessionTotal;
     let availableBalanceMaintenance: number =
       balance + upnlTotal + unpaidFundingTotal - mmTotal;
     let availableBalanceMaintenanceIncludingOrders: number =

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -565,7 +565,7 @@ export class SubClient {
       options.tifOptions
     );
 
-    let orderIx = instructions.placePerpOrderV3Ix(
+    let orderIx = instructions.placePerpOrderV4Ix(
       this.asset,
       price,
       size,
@@ -573,6 +573,7 @@ export class SubClient {
       options.orderType != undefined
         ? options.orderType
         : types.OrderType.LIMIT,
+      options.reduceOnly != undefined ? options.reduceOnly : false,
       options.clientOrderId != undefined ? options.clientOrderId : 0,
       options.tag != undefined ? options.tag : constants.DEFAULT_ORDER_TAG,
       tifOffsetToUse,
@@ -670,7 +671,7 @@ export class SubClient {
       options.tifOptions
     );
 
-    return instructions.placePerpOrderV3Ix(
+    return instructions.placePerpOrderV4Ix(
       this.asset,
       price,
       size,
@@ -678,6 +679,7 @@ export class SubClient {
       options.orderType != undefined
         ? options.orderType
         : types.OrderType.LIMIT,
+      options.reduceOnly != undefined ? options.reduceOnly : false,
       options.clientOrderId != undefined ? options.clientOrderId : 0,
       options.tag != undefined ? options.tag : constants.DEFAULT_ORDER_TAG,
       tifOffset,
@@ -793,7 +795,7 @@ export class SubClient {
     );
 
     tx.add(
-      instructions.placePerpOrderV3Ix(
+      instructions.placePerpOrderV4Ix(
         this.asset,
         newOrderPrice,
         newOrderSize,
@@ -801,6 +803,7 @@ export class SubClient {
         options.orderType != undefined
           ? options.orderType
           : types.OrderType.LIMIT,
+        options.reduceOnly != undefined ? options.reduceOnly : false,
         options.clientOrderId != undefined ? options.clientOrderId : 0,
         options.tag != undefined ? options.tag : constants.DEFAULT_ORDER_TAG,
         tifOffsetToUse,
@@ -859,7 +862,7 @@ export class SubClient {
     );
 
     tx.add(
-      instructions.placePerpOrderV3Ix(
+      instructions.placePerpOrderV4Ix(
         this.asset,
         newOrderPrice,
         newOrderSize,
@@ -867,6 +870,7 @@ export class SubClient {
         newOptions.orderType != undefined
           ? newOptions.orderType
           : types.OrderType.LIMIT,
+        newOptions.reduceOnly != undefined ? newOptions.reduceOnly : false,
         newOptions.clientOrderId != undefined ? newOptions.clientOrderId : 0,
         newOptions.tag != undefined
           ? newOptions.tag
@@ -928,7 +932,7 @@ export class SubClient {
     );
 
     tx.add(
-      instructions.placePerpOrderV3Ix(
+      instructions.placePerpOrderV4Ix(
         this.asset,
         newOrderPrice,
         newOrderSize,
@@ -936,6 +940,7 @@ export class SubClient {
         newOptions.orderType != undefined
           ? newOptions.orderType
           : types.OrderType.LIMIT,
+        newOptions.reduceOnly != undefined ? newOptions.reduceOnly : false,
         newOptions.clientOrderId != undefined ? newOptions.clientOrderId : 0,
         newOptions.tag != undefined
           ? newOptions.tag

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,9 +64,24 @@ export function toProgramOrderType(orderType: OrderType) {
   if (orderType == OrderType.POSTONLYSLIDE) return { postOnlySlide: {} };
 }
 
+export function fromProgramOrderType(orderType: any): OrderType {
+  if (objectEquals(orderType, { limit: {} })) return OrderType.LIMIT;
+  if (objectEquals(orderType, { postOnly: {} })) return OrderType.POSTONLY;
+  if (objectEquals(orderType, { fillOrKill: {} })) return OrderType.FILLORKILL;
+  if (objectEquals(orderType, { immediateOrCancel: {} }))
+    return OrderType.IMMEDIATEORCANCEL;
+  if (objectEquals(orderType, { postOnlySlide: {} }))
+    return OrderType.POSTONLYSLIDE;
+}
+
 export enum Side {
   BID,
   ASK,
+}
+
+export enum TriggerDirection {
+  INCREASING,
+  DECREASING,
 }
 
 export enum UserCallbackType {
@@ -90,6 +105,26 @@ export function fromProgramSide(side: any): Side {
     return Side.ASK;
   }
   throw Error("Invalid program side!");
+}
+
+export function toProgramTriggerDirection(triggerDirection: TriggerDirection) {
+  if (triggerDirection == TriggerDirection.INCREASING)
+    return { increasing: {} };
+  if (triggerDirection == TriggerDirection.DECREASING)
+    return { decreasing: {} };
+  throw Error("Invalid triggerDirection");
+}
+
+export function fromProgramTriggerDirection(
+  triggerDirection: any
+): TriggerDirection {
+  if (objectEquals(triggerDirection, { increasing: {} })) {
+    return TriggerDirection.INCREASING;
+  }
+  if (objectEquals(triggerDirection, { decreasing: {} })) {
+    return TriggerDirection.DECREASING;
+  }
+  throw Error("Invalid program triggerDirection!");
 }
 
 export enum Kind {
@@ -123,6 +158,19 @@ export interface Order {
   clientOrderId: BN;
   tifOffset: number;
   asset: Asset;
+}
+
+export interface TriggerOrder {
+  orderPrice: number;
+  triggerPrice: number;
+  size: number;
+  clientOrderId: number;
+  creationTs: number;
+  triggerDirection: TriggerDirection;
+  side: Side;
+  asset: Asset;
+  orderType: OrderType;
+  triggerOrderIndex: number;
 }
 
 export function orderEquals(
@@ -347,6 +395,27 @@ export interface OrderOptions {
   clientOrderId?: number;
   tag?: string;
   blockhash?: { blockhash: string; lastValidBlockHeight: number };
+}
+
+export interface TriggerOrderOptions {
+  triggerDirection: TriggerDirection;
+  orderType?: types.OrderType;
+  clientOrderId?: number;
+  tag?: string;
+  blockhash?: { blockhash: string; lastValidBlockHeight: number };
+}
+
+export function defaultTriggerOrderOptions(side: Side): TriggerOrderOptions {
+  return {
+    triggerDirection:
+      side == Side.BID
+        ? TriggerDirection.DECREASING
+        : TriggerDirection.INCREASING,
+    orderType: OrderType.FILLORKILL,
+    clientOrderId: 0,
+    tag: constants.DEFAULT_ORDER_TAG,
+    blockhash: undefined,
+  };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,6 +399,7 @@ export function fromProgramOrderCompleteType(
 export interface OrderOptions {
   tifOptions: TIFOptions;
   orderType?: types.OrderType;
+  reduceOnly?: boolean;
   clientOrderId?: number;
   tag?: string;
   blockhash?: { blockhash: string; lastValidBlockHeight: number };
@@ -406,6 +407,7 @@ export interface OrderOptions {
 
 export interface TriggerOrderOptions {
   orderType?: types.OrderType;
+  reduceOnly?: boolean;
   clientOrderId?: number;
   tag?: string;
   blockhash?: { blockhash: string; lastValidBlockHeight: number };
@@ -420,6 +422,7 @@ export function getDefaultTriggerDirection(side: Side): TriggerDirection {
 export function defaultTriggerOrderOptions(): TriggerOrderOptions {
   return {
     orderType: OrderType.FILLORKILL,
+    reduceOnly: false,
     clientOrderId: 0,
     tag: constants.DEFAULT_ORDER_TAG,
     blockhash: undefined,
@@ -443,6 +446,7 @@ export function defaultOrderOptions(): OrderOptions {
       expiryTs: undefined,
     },
     orderType: OrderType.LIMIT,
+    reduceOnly: false,
     clientOrderId: 0,
     tag: constants.DEFAULT_ORDER_TAG,
     blockhash: undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -416,8 +416,8 @@ export function defaultTriggerOrderOptions(side: Side): TriggerOrderOptions {
   return {
     triggerDirection:
       side == Side.BID
-        ? TriggerDirection.GREATERTHANOREQUAL
-        : TriggerDirection.LESSTHANOREQUAL,
+        ? TriggerDirection.LESSTHANOREQUAL
+        : TriggerDirection.GREATERTHANOREQUAL,
     orderType: OrderType.FILLORKILL,
     clientOrderId: 0,
     tag: constants.DEFAULT_ORDER_TAG,

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,7 +176,6 @@ export interface TriggerOrder {
   orderPrice: number;
   triggerPrice: number | null;
   size: number;
-  clientOrderId: number;
   creationTs: number;
   triggerDirection: TriggerDirection | null;
   triggerTimestamp: anchor.BN | null;
@@ -418,7 +417,6 @@ export interface OrderOptions {
 export interface TriggerOrderOptions {
   orderType?: types.OrderType;
   reduceOnly?: boolean;
-  clientOrderId?: number;
   tag?: string;
   blockhash?: { blockhash: string; lastValidBlockHeight: number };
 }
@@ -433,7 +431,6 @@ export function defaultTriggerOrderOptions(): TriggerOrderOptions {
   return {
     orderType: OrderType.FILLORKILL,
     reduceOnly: false,
-    clientOrderId: 0,
     tag: constants.DEFAULT_ORDER_TAG,
     blockhash: undefined,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export enum Side {
 }
 
 export enum TriggerDirection {
+  UNINITIALIZED,
   LESSTHANOREQUAL,
   GREATERTHANOREQUAL,
 }
@@ -108,6 +109,8 @@ export function fromProgramSide(side: any): Side {
 }
 
 export function toProgramTriggerDirection(triggerDirection: TriggerDirection) {
+  if (triggerDirection == TriggerDirection.UNINITIALIZED)
+    return { uninitialized: {} };
   if (triggerDirection == TriggerDirection.LESSTHANOREQUAL)
     return { lessThanOrEqual: {} };
   if (triggerDirection == TriggerDirection.GREATERTHANOREQUAL)
@@ -118,6 +121,9 @@ export function toProgramTriggerDirection(triggerDirection: TriggerDirection) {
 export function fromProgramTriggerDirection(
   triggerDirection: any
 ): TriggerDirection {
+  if (objectEquals(triggerDirection, { uninitialized: {} })) {
+    return TriggerDirection.UNINITIALIZED;
+  }
   if (objectEquals(triggerDirection, { lessThanOrEqual: {} })) {
     return TriggerDirection.LESSTHANOREQUAL;
   }
@@ -162,11 +168,12 @@ export interface Order {
 
 export interface TriggerOrder {
   orderPrice: number;
-  triggerPrice: number;
+  triggerPrice: number | null;
   size: number;
   clientOrderId: number;
   creationTs: number;
-  triggerDirection: TriggerDirection;
+  triggerDirection: TriggerDirection | null;
+  triggerTimestamp: number | null;
   side: Side;
   asset: Asset;
   orderType: OrderType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -405,19 +405,20 @@ export interface OrderOptions {
 }
 
 export interface TriggerOrderOptions {
-  triggerDirection: TriggerDirection;
   orderType?: types.OrderType;
   clientOrderId?: number;
   tag?: string;
   blockhash?: { blockhash: string; lastValidBlockHeight: number };
 }
 
-export function defaultTriggerOrderOptions(side: Side): TriggerOrderOptions {
+export function getDefaultTriggerDirection(side: Side): TriggerDirection {
+  return side == Side.BID
+    ? TriggerDirection.LESSTHANOREQUAL
+    : TriggerDirection.GREATERTHANOREQUAL;
+}
+
+export function defaultTriggerOrderOptions(): TriggerOrderOptions {
   return {
-    triggerDirection:
-      side == Side.BID
-        ? TriggerDirection.LESSTHANOREQUAL
-        : TriggerDirection.GREATERTHANOREQUAL,
     orderType: OrderType.FILLORKILL,
     clientOrderId: 0,
     tag: constants.DEFAULT_ORDER_TAG,

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,8 +80,8 @@ export enum Side {
 }
 
 export enum TriggerDirection {
-  INCREASING,
-  DECREASING,
+  LESSTHANOREQUAL,
+  GREATERTHANOREQUAL,
 }
 
 export enum UserCallbackType {
@@ -108,21 +108,21 @@ export function fromProgramSide(side: any): Side {
 }
 
 export function toProgramTriggerDirection(triggerDirection: TriggerDirection) {
-  if (triggerDirection == TriggerDirection.INCREASING)
-    return { increasing: {} };
-  if (triggerDirection == TriggerDirection.DECREASING)
-    return { decreasing: {} };
+  if (triggerDirection == TriggerDirection.LESSTHANOREQUAL)
+    return { lessThanOrEqual: {} };
+  if (triggerDirection == TriggerDirection.GREATERTHANOREQUAL)
+    return { greaterThanOrEqual: {} };
   throw Error("Invalid triggerDirection");
 }
 
 export function fromProgramTriggerDirection(
   triggerDirection: any
 ): TriggerDirection {
-  if (objectEquals(triggerDirection, { increasing: {} })) {
-    return TriggerDirection.INCREASING;
+  if (objectEquals(triggerDirection, { lessThanOrEqual: {} })) {
+    return TriggerDirection.LESSTHANOREQUAL;
   }
-  if (objectEquals(triggerDirection, { decreasing: {} })) {
-    return TriggerDirection.DECREASING;
+  if (objectEquals(triggerDirection, { greaterThanOrEqual: {} })) {
+    return TriggerDirection.GREATERTHANOREQUAL;
   }
   throw Error("Invalid program triggerDirection!");
 }
@@ -409,8 +409,8 @@ export function defaultTriggerOrderOptions(side: Side): TriggerOrderOptions {
   return {
     triggerDirection:
       side == Side.BID
-        ? TriggerDirection.DECREASING
-        : TriggerDirection.INCREASING,
+        ? TriggerDirection.GREATERTHANOREQUAL
+        : TriggerDirection.LESSTHANOREQUAL,
     orderType: OrderType.FILLORKILL,
     clientOrderId: 0,
     tag: constants.DEFAULT_ORDER_TAG,

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,7 +173,7 @@ export interface TriggerOrder {
   clientOrderId: number;
   creationTs: number;
   triggerDirection: TriggerDirection | null;
-  triggerTimestamp: number | null;
+  triggerTimestamp: anchor.BN | null;
   side: Side;
   asset: Asset;
   orderType: OrderType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,7 @@ export interface TriggerOrder {
   side: Side;
   asset: Asset;
   orderType: OrderType;
+  reduceOnly: boolean;
   triggerOrderBit: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,7 +170,7 @@ export interface TriggerOrder {
   side: Side;
   asset: Asset;
   orderType: OrderType;
-  triggerOrderIndex: number;
+  triggerOrderBit: number;
 }
 
 export function orderEquals(

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -3938,6 +3938,350 @@ export type Zeta = {
       ]
     },
     {
+      "name": "placeTriggerOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "openOrders",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "pricing",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "dexProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "market",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        },
+        {
+          "name": "orderPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerDirection",
+          "type": {
+            "defined": "TriggerDirection"
+          }
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "tag",
+          "type": {
+            "option": "string"
+          }
+        },
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
+    },
+    {
+      "name": "executeTriggerOrder",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "placeOrderAccounts",
+          "accounts": [
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pricing",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "rent",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketAccounts",
+              "accounts": [
+                {
+                  "name": "market",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "requestQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "eventQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "bids",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "asks",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "orderPayerTokenAccount",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinWallet",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcWallet",
+                  "isMut": true,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "oracle",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupFeed",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mintAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "perpSyncQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "cancelTriggerOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "editTriggerOrder",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerDirection",
+          "type": {
+            "defined": "TriggerDirection"
+          }
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
       "name": "cancelOrder",
       "accounts": [
         {
@@ -6161,11 +6505,15 @@ export type Zeta = {
             }
           },
           {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                338
+                334
               ]
             }
           }
@@ -6632,11 +6980,15 @@ export type Zeta = {
             }
           },
           {
+            "name": "triggerOrderIndexes",
+            "type": "u128"
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                2000
+                1984
               ]
             }
           }
@@ -6747,6 +7099,74 @@ export type Zeta = {
                 "u8",
                 338
               ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "triggerOrderInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "marginAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "openOrders",
+            "type": "publicKey"
+          },
+          {
+            "name": "whitelistTradingFeesAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "orderPrice",
+            "type": "u64"
+          },
+          {
+            "name": "triggerPrice",
+            "type": "u64"
+          },
+          {
+            "name": "size",
+            "type": "u64"
+          },
+          {
+            "name": "clientOrderId",
+            "type": "u64"
+          },
+          {
+            "name": "creationTs",
+            "type": "u64"
+          },
+          {
+            "name": "triggerDirection",
+            "type": {
+              "defined": "TriggerDirection"
+            }
+          },
+          {
+            "name": "side",
+            "type": {
+              "defined": "Side"
+            }
+          },
+          {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
+            "name": "orderType",
+            "type": {
+              "defined": "OrderType"
             }
           }
         ]
@@ -7562,6 +7982,10 @@ export type Zeta = {
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
+          },
+          {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
           }
         ]
       }
@@ -7674,6 +8098,10 @@ export type Zeta = {
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
+          },
+          {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
           }
         ]
       }
@@ -8103,6 +8531,23 @@ export type Zeta = {
           },
           {
             "name": "Ask"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Uninitialized"
+          },
+          {
+            "name": "Increasing"
+          },
+          {
+            "name": "Decreasing"
           }
         ]
       }
@@ -9369,6 +9814,51 @@ export type Zeta = {
       "code": 6144,
       "name": "MarginAccountCannotLiquidateCrossMarginAccount",
       "msg": "MarginAccount cannot liquidate CrossMarginAccount"
+    },
+    {
+      "code": 6145,
+      "name": "TriggerOrderCannotBeRemoved",
+      "msg": "Trigger order cannot be removed"
+    },
+    {
+      "code": 6146,
+      "name": "TriggerOrderCannotBeExecuted",
+      "msg": "Trigger order cannot be executed"
+    },
+    {
+      "code": 6147,
+      "name": "TriggerOrderOnlySupportsCrossMarginAccounts",
+      "msg": "Trigger order only supports CrossMarginAccounts"
+    },
+    {
+      "code": 6148,
+      "name": "TooManyTriggerOrders",
+      "msg": "Too many trigger orders, close some and retry"
+    },
+    {
+      "code": 6149,
+      "name": "InvalidTriggerOrderRemainingAccounts",
+      "msg": "Invalid trigger order remaining accounts"
+    },
+    {
+      "code": 6150,
+      "name": "InvalidTriggerOrderWhitelistFeesAccount",
+      "msg": "Invalid trigger order whitelist fees account"
+    },
+    {
+      "code": 6151,
+      "name": "MissingTriggerOrderWhitelistFeesAccount",
+      "msg": "Missing trigger order whitelist fees account"
+    },
+    {
+      "code": 6152,
+      "name": "InvalidTriggerOrderIndex",
+      "msg": "Invalid trigger order index"
+    },
+    {
+      "code": 6153,
+      "name": "InvalidSecondaryAdmin",
+      "msg": "Invalid secondary admin"
     }
   ]
 };
@@ -13313,6 +13803,350 @@ export const IDL: Zeta = {
       ]
     },
     {
+      "name": "placeTriggerOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "openOrders",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "authority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "pricing",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "dexProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "market",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        },
+        {
+          "name": "orderPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerDirection",
+          "type": {
+            "defined": "TriggerDirection"
+          }
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "tag",
+          "type": {
+            "option": "string"
+          }
+        },
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
+    },
+    {
+      "name": "executeTriggerOrder",
+      "accounts": [
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "placeOrderAccounts",
+          "accounts": [
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pricing",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "rent",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketAccounts",
+              "accounts": [
+                {
+                  "name": "market",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "requestQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "eventQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "bids",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "asks",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "orderPayerTokenAccount",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinWallet",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcWallet",
+                  "isMut": true,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "oracle",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupFeed",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mintAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "perpSyncQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "cancelTriggerOrder",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "admin",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "payer",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "marginAccount",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "triggerOrderIndex",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "editTriggerOrder",
+      "accounts": [
+        {
+          "name": "owner",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "triggerOrderInfo",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "orderPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerPrice",
+          "type": "u64"
+        },
+        {
+          "name": "triggerDirection",
+          "type": {
+            "defined": "TriggerDirection"
+          }
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
       "name": "cancelOrder",
       "accounts": [
         {
@@ -15536,11 +16370,15 @@ export const IDL: Zeta = {
             }
           },
           {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                338
+                334
               ]
             }
           }
@@ -16007,11 +16845,15 @@ export const IDL: Zeta = {
             }
           },
           {
+            "name": "triggerOrderIndexes",
+            "type": "u128"
+          },
+          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                2000
+                1984
               ]
             }
           }
@@ -16122,6 +16964,74 @@ export const IDL: Zeta = {
                 "u8",
                 338
               ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "triggerOrderInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "type": "publicKey"
+          },
+          {
+            "name": "marginAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "openOrders",
+            "type": "publicKey"
+          },
+          {
+            "name": "whitelistTradingFeesAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "orderPrice",
+            "type": "u64"
+          },
+          {
+            "name": "triggerPrice",
+            "type": "u64"
+          },
+          {
+            "name": "size",
+            "type": "u64"
+          },
+          {
+            "name": "clientOrderId",
+            "type": "u64"
+          },
+          {
+            "name": "creationTs",
+            "type": "u64"
+          },
+          {
+            "name": "triggerDirection",
+            "type": {
+              "defined": "TriggerDirection"
+            }
+          },
+          {
+            "name": "side",
+            "type": {
+              "defined": "Side"
+            }
+          },
+          {
+            "name": "asset",
+            "type": {
+              "defined": "Asset"
+            }
+          },
+          {
+            "name": "orderType",
+            "type": {
+              "defined": "OrderType"
             }
           }
         ]
@@ -16937,6 +17847,10 @@ export const IDL: Zeta = {
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
+          },
+          {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
           }
         ]
       }
@@ -17049,6 +17963,10 @@ export const IDL: Zeta = {
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
+          },
+          {
+            "name": "triggerOrderTimeoutSeconds",
+            "type": "u32"
           }
         ]
       }
@@ -17478,6 +18396,23 @@ export const IDL: Zeta = {
           },
           {
             "name": "Ask"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TriggerDirection",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Uninitialized"
+          },
+          {
+            "name": "Increasing"
+          },
+          {
+            "name": "Decreasing"
           }
         ]
       }
@@ -18744,6 +19679,51 @@ export const IDL: Zeta = {
       "code": 6144,
       "name": "MarginAccountCannotLiquidateCrossMarginAccount",
       "msg": "MarginAccount cannot liquidate CrossMarginAccount"
+    },
+    {
+      "code": 6145,
+      "name": "TriggerOrderCannotBeRemoved",
+      "msg": "Trigger order cannot be removed"
+    },
+    {
+      "code": 6146,
+      "name": "TriggerOrderCannotBeExecuted",
+      "msg": "Trigger order cannot be executed"
+    },
+    {
+      "code": 6147,
+      "name": "TriggerOrderOnlySupportsCrossMarginAccounts",
+      "msg": "Trigger order only supports CrossMarginAccounts"
+    },
+    {
+      "code": 6148,
+      "name": "TooManyTriggerOrders",
+      "msg": "Too many trigger orders, close some and retry"
+    },
+    {
+      "code": 6149,
+      "name": "InvalidTriggerOrderRemainingAccounts",
+      "msg": "Invalid trigger order remaining accounts"
+    },
+    {
+      "code": 6150,
+      "name": "InvalidTriggerOrderWhitelistFeesAccount",
+      "msg": "Invalid trigger order whitelist fees account"
+    },
+    {
+      "code": 6151,
+      "name": "MissingTriggerOrderWhitelistFeesAccount",
+      "msg": "Missing trigger order whitelist fees account"
+    },
+    {
+      "code": 6152,
+      "name": "InvalidTriggerOrderIndex",
+      "msg": "Invalid trigger order index"
+    },
+    {
+      "code": 6153,
+      "name": "InvalidSecondaryAdmin",
+      "msg": "Invalid secondary admin"
     }
   ]
 };

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -3938,6 +3938,196 @@ export type Zeta = {
       ]
     },
     {
+      "name": "placePerpOrderV4",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "placeOrderAccounts",
+          "accounts": [
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pricing",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "rent",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketAccounts",
+              "accounts": [
+                {
+                  "name": "market",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "requestQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "eventQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "bids",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "asks",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "orderPayerTokenAccount",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinWallet",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcWallet",
+                  "isMut": true,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "oracle",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupFeed",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mintAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "perpSyncQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "price",
+          "type": "u64"
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "tag",
+          "type": {
+            "option": "string"
+          }
+        },
+        {
+          "name": "tifOffset",
+          "type": {
+            "option": "u16"
+          }
+        },
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
+    },
+    {
       "name": "placeTriggerOrder",
       "accounts": [
         {
@@ -4030,6 +4220,10 @@ export type Zeta = {
           "type": {
             "defined": "OrderType"
           }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
         },
         {
           "name": "clientOrderId",
@@ -4292,6 +4486,10 @@ export type Zeta = {
           "type": {
             "defined": "OrderType"
           }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
         },
         {
           "name": "clientOrderId",
@@ -7200,6 +7398,10 @@ export type Zeta = {
             "type": {
               "defined": "OrderType"
             }
+          },
+          {
+            "name": "reduceOnly",
+            "type": "bool"
           }
         ]
       }
@@ -13850,6 +14052,196 @@ export const IDL: Zeta = {
       ]
     },
     {
+      "name": "placePerpOrderV4",
+      "accounts": [
+        {
+          "name": "authority",
+          "isMut": false,
+          "isSigner": true
+        },
+        {
+          "name": "placeOrderAccounts",
+          "accounts": [
+            {
+              "name": "state",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "pricing",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marginAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "dexProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "serumAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "openOrders",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "rent",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketAccounts",
+              "accounts": [
+                {
+                  "name": "market",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "requestQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "eventQueue",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "bids",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "asks",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "orderPayerTokenAccount",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcVault",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "coinWallet",
+                  "isMut": true,
+                  "isSigner": false
+                },
+                {
+                  "name": "pcWallet",
+                  "isMut": true,
+                  "isSigner": false
+                }
+              ]
+            },
+            {
+              "name": "oracle",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupFeed",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "oracleBackupProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "marketMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "mintAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "perpSyncQueue",
+              "isMut": true,
+              "isSigner": false
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "price",
+          "type": "u64"
+        },
+        {
+          "name": "size",
+          "type": "u64"
+        },
+        {
+          "name": "side",
+          "type": {
+            "defined": "Side"
+          }
+        },
+        {
+          "name": "orderType",
+          "type": {
+            "defined": "OrderType"
+          }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
+        },
+        {
+          "name": "clientOrderId",
+          "type": {
+            "option": "u64"
+          }
+        },
+        {
+          "name": "tag",
+          "type": {
+            "option": "string"
+          }
+        },
+        {
+          "name": "tifOffset",
+          "type": {
+            "option": "u16"
+          }
+        },
+        {
+          "name": "asset",
+          "type": {
+            "defined": "Asset"
+          }
+        }
+      ]
+    },
+    {
       "name": "placeTriggerOrder",
       "accounts": [
         {
@@ -13942,6 +14334,10 @@ export const IDL: Zeta = {
           "type": {
             "defined": "OrderType"
           }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
         },
         {
           "name": "clientOrderId",
@@ -14204,6 +14600,10 @@ export const IDL: Zeta = {
           "type": {
             "defined": "OrderType"
           }
+        },
+        {
+          "name": "reduceOnly",
+          "type": "bool"
         },
         {
           "name": "clientOrderId",
@@ -17112,6 +17512,10 @@ export const IDL: Zeta = {
             "type": {
               "defined": "OrderType"
             }
+          },
+          {
+            "name": "reduceOnly",
+            "type": "bool"
           }
         ]
       }

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -7340,10 +7340,6 @@ export type Zeta = {
             "type": "publicKey"
           },
           {
-            "name": "whitelistTradingFeesAccount",
-            "type": "publicKey"
-          },
-          {
             "name": "orderPrice",
             "type": "u64"
           },
@@ -10071,51 +10067,46 @@ export type Zeta = {
     },
     {
       "code": 6148,
-      "name": "TriggerOrderOnlySupportsCrossMarginAccounts",
-      "msg": "Trigger order only supports CrossMarginAccounts"
-    },
-    {
-      "code": 6149,
       "name": "TooManyTriggerOrders",
       "msg": "Too many trigger orders, close some and retry"
     },
     {
-      "code": 6150,
+      "code": 6149,
       "name": "InvalidTriggerOrderRemainingAccounts",
       "msg": "Invalid trigger order remaining accounts"
     },
     {
-      "code": 6151,
+      "code": 6150,
       "name": "InvalidTriggerOrderWhitelistFeesAccount",
       "msg": "Invalid trigger order whitelist fees account"
     },
     {
-      "code": 6152,
+      "code": 6151,
       "name": "MissingTriggerOrderWhitelistFeesAccount",
       "msg": "Missing trigger order whitelist fees account"
     },
     {
-      "code": 6153,
+      "code": 6152,
       "name": "InvalidTriggerOrderBitRange",
       "msg": "Invalid trigger order bit range"
     },
     {
-      "code": 6154,
+      "code": 6153,
       "name": "InvalidSecondaryAdmin",
       "msg": "Invalid secondary admin"
     },
     {
-      "code": 6155,
+      "code": 6154,
       "name": "OnlyOwnerCanEditTriggerOrder",
       "msg": "Only the owner can edit their own trigger order"
     },
     {
-      "code": 6156,
+      "code": 6155,
       "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
       "msg": "Trigger order needs either a trigger price + direction, or trigger time"
     },
     {
-      "code": 6157,
+      "code": 6156,
       "name": "TriggerOrderBitOccupied",
       "msg": "Given trigger order bit is occupied, pick another"
     }
@@ -17464,10 +17455,6 @@ export const IDL: Zeta = {
             "type": "publicKey"
           },
           {
-            "name": "whitelistTradingFeesAccount",
-            "type": "publicKey"
-          },
-          {
             "name": "orderPrice",
             "type": "u64"
           },
@@ -20195,51 +20182,46 @@ export const IDL: Zeta = {
     },
     {
       "code": 6148,
-      "name": "TriggerOrderOnlySupportsCrossMarginAccounts",
-      "msg": "Trigger order only supports CrossMarginAccounts"
-    },
-    {
-      "code": 6149,
       "name": "TooManyTriggerOrders",
       "msg": "Too many trigger orders, close some and retry"
     },
     {
-      "code": 6150,
+      "code": 6149,
       "name": "InvalidTriggerOrderRemainingAccounts",
       "msg": "Invalid trigger order remaining accounts"
     },
     {
-      "code": 6151,
+      "code": 6150,
       "name": "InvalidTriggerOrderWhitelistFeesAccount",
       "msg": "Invalid trigger order whitelist fees account"
     },
     {
-      "code": 6152,
+      "code": 6151,
       "name": "MissingTriggerOrderWhitelistFeesAccount",
       "msg": "Missing trigger order whitelist fees account"
     },
     {
-      "code": 6153,
+      "code": 6152,
       "name": "InvalidTriggerOrderBitRange",
       "msg": "Invalid trigger order bit range"
     },
     {
-      "code": 6154,
+      "code": 6153,
       "name": "InvalidSecondaryAdmin",
       "msg": "Invalid secondary admin"
     },
     {
-      "code": 6155,
+      "code": 6154,
       "name": "OnlyOwnerCanEditTriggerOrder",
       "msg": "Only the owner can edit their own trigger order"
     },
     {
-      "code": 6156,
+      "code": 6155,
       "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
       "msg": "Trigger order needs either a trigger price + direction, or trigger time"
     },
     {
-      "code": 6157,
+      "code": 6156,
       "name": "TriggerOrderBitOccupied",
       "msg": "Given trigger order bit is occupied, pick another"
     }

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -4226,12 +4226,6 @@ export type Zeta = {
           "type": "bool"
         },
         {
-          "name": "clientOrderId",
-          "type": {
-            "option": "u64"
-          }
-        },
-        {
           "name": "tag",
           "type": {
             "option": "string"
@@ -4490,12 +4484,6 @@ export type Zeta = {
         {
           "name": "reduceOnly",
           "type": "bool"
-        },
-        {
-          "name": "clientOrderId",
-          "type": {
-            "option": "u64"
-          }
         }
       ]
     },
@@ -6723,15 +6711,11 @@ export type Zeta = {
             }
           },
           {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
-          },
-          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                334
+                338
               ]
             }
           }
@@ -7360,12 +7344,6 @@ export type Zeta = {
             "type": "u64"
           },
           {
-            "name": "clientOrderId",
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
             "name": "creationTs",
             "type": "u64"
           },
@@ -7394,6 +7372,10 @@ export type Zeta = {
             "type": {
               "defined": "OrderType"
             }
+          },
+          {
+            "name": "bit",
+            "type": "u8"
           },
           {
             "name": "reduceOnly",
@@ -8212,10 +8194,6 @@ export type Zeta = {
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
-          },
-          {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
           }
         ]
       }
@@ -8328,10 +8306,6 @@ export type Zeta = {
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
-          },
-          {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
           }
         ]
       }
@@ -14341,12 +14315,6 @@ export const IDL: Zeta = {
           "type": "bool"
         },
         {
-          "name": "clientOrderId",
-          "type": {
-            "option": "u64"
-          }
-        },
-        {
           "name": "tag",
           "type": {
             "option": "string"
@@ -14605,12 +14573,6 @@ export const IDL: Zeta = {
         {
           "name": "reduceOnly",
           "type": "bool"
-        },
-        {
-          "name": "clientOrderId",
-          "type": {
-            "option": "u64"
-          }
         }
       ]
     },
@@ -16838,15 +16800,11 @@ export const IDL: Zeta = {
             }
           },
           {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
-          },
-          {
             "name": "padding",
             "type": {
               "array": [
                 "u8",
-                334
+                338
               ]
             }
           }
@@ -17475,12 +17433,6 @@ export const IDL: Zeta = {
             "type": "u64"
           },
           {
-            "name": "clientOrderId",
-            "type": {
-              "option": "u64"
-            }
-          },
-          {
             "name": "creationTs",
             "type": "u64"
           },
@@ -17509,6 +17461,10 @@ export const IDL: Zeta = {
             "type": {
               "defined": "OrderType"
             }
+          },
+          {
+            "name": "bit",
+            "type": "u8"
           },
           {
             "name": "reduceOnly",
@@ -18327,10 +18283,6 @@ export const IDL: Zeta = {
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
-          },
-          {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
           }
         ]
       }
@@ -18443,10 +18395,6 @@ export const IDL: Zeta = {
           {
             "name": "nativeOpenInterestLimit",
             "type": "u64"
-          },
-          {
-            "name": "triggerOrderTimeoutSeconds",
-            "type": "u32"
           }
         ]
       }

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -8544,10 +8544,10 @@ export type Zeta = {
             "name": "Uninitialized"
           },
           {
-            "name": "Increasing"
+            "name": "LessThanOrEqual"
           },
           {
-            "name": "Decreasing"
+            "name": "GreaterThanOrEqual"
           }
         ]
       }
@@ -18414,10 +18414,10 @@ export const IDL: Zeta = {
             "name": "Uninitialized"
           },
           {
-            "name": "Increasing"
+            "name": "LessThanOrEqual"
           },
           {
-            "name": "Decreasing"
+            "name": "GreaterThanOrEqual"
           }
         ]
       }

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -3997,12 +3997,22 @@ export type Zeta = {
         },
         {
           "name": "triggerPrice",
-          "type": "u64"
+          "type": {
+            "option": "u64"
+          }
         },
         {
           "name": "triggerDirection",
           "type": {
-            "defined": "TriggerDirection"
+            "option": {
+              "defined": "TriggerDirection"
+            }
+          }
+        },
+        {
+          "name": "triggerTs",
+          "type": {
+            "option": "u64"
           }
         },
         {
@@ -4249,12 +4259,22 @@ export type Zeta = {
         },
         {
           "name": "triggerPrice",
-          "type": "u64"
+          "type": {
+            "option": "u64"
+          }
         },
         {
           "name": "triggerDirection",
           "type": {
-            "defined": "TriggerDirection"
+            "option": {
+              "defined": "TriggerDirection"
+            }
+          }
+        },
+        {
+          "name": "triggerTs",
+          "type": {
+            "option": "u64"
           }
         },
         {
@@ -7131,7 +7151,15 @@ export type Zeta = {
           },
           {
             "name": "triggerPrice",
-            "type": "u64"
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "triggerTs",
+            "type": {
+              "option": "u64"
+            }
           },
           {
             "name": "size",
@@ -7139,7 +7167,9 @@ export type Zeta = {
           },
           {
             "name": "clientOrderId",
-            "type": "u64"
+            "type": {
+              "option": "u64"
+            }
           },
           {
             "name": "creationTs",
@@ -7148,7 +7178,9 @@ export type Zeta = {
           {
             "name": "triggerDirection",
             "type": {
-              "defined": "TriggerDirection"
+              "option": {
+                "defined": "TriggerDirection"
+              }
             }
           },
           {
@@ -9864,6 +9896,11 @@ export type Zeta = {
       "code": 6154,
       "name": "OnlyOwnerCanEditTriggerOrder",
       "msg": "Only the owner can edit their own trigger order"
+    },
+    {
+      "code": 6155,
+      "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
+      "msg": "Trigger order needs either a trigger price + direction, or trigger time"
     }
   ]
 };
@@ -13867,12 +13904,22 @@ export const IDL: Zeta = {
         },
         {
           "name": "triggerPrice",
-          "type": "u64"
+          "type": {
+            "option": "u64"
+          }
         },
         {
           "name": "triggerDirection",
           "type": {
-            "defined": "TriggerDirection"
+            "option": {
+              "defined": "TriggerDirection"
+            }
+          }
+        },
+        {
+          "name": "triggerTs",
+          "type": {
+            "option": "u64"
           }
         },
         {
@@ -14119,12 +14166,22 @@ export const IDL: Zeta = {
         },
         {
           "name": "triggerPrice",
-          "type": "u64"
+          "type": {
+            "option": "u64"
+          }
         },
         {
           "name": "triggerDirection",
           "type": {
-            "defined": "TriggerDirection"
+            "option": {
+              "defined": "TriggerDirection"
+            }
+          }
+        },
+        {
+          "name": "triggerTs",
+          "type": {
+            "option": "u64"
           }
         },
         {
@@ -17001,7 +17058,15 @@ export const IDL: Zeta = {
           },
           {
             "name": "triggerPrice",
-            "type": "u64"
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "triggerTs",
+            "type": {
+              "option": "u64"
+            }
           },
           {
             "name": "size",
@@ -17009,7 +17074,9 @@ export const IDL: Zeta = {
           },
           {
             "name": "clientOrderId",
-            "type": "u64"
+            "type": {
+              "option": "u64"
+            }
           },
           {
             "name": "creationTs",
@@ -17018,7 +17085,9 @@ export const IDL: Zeta = {
           {
             "name": "triggerDirection",
             "type": {
-              "defined": "TriggerDirection"
+              "option": {
+                "defined": "TriggerDirection"
+              }
             }
           },
           {
@@ -19734,6 +19803,11 @@ export const IDL: Zeta = {
       "code": 6154,
       "name": "OnlyOwnerCanEditTriggerOrder",
       "msg": "Only the owner can edit their own trigger order"
+    },
+    {
+      "code": 6155,
+      "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
+      "msg": "Trigger order needs either a trigger price + direction, or trigger time"
     }
   ]
 };

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -9884,8 +9884,8 @@ export type Zeta = {
     },
     {
       "code": 6152,
-      "name": "InvalidTriggerOrderBit",
-      "msg": "Invalid trigger order index"
+      "name": "InvalidTriggerOrderBitRange",
+      "msg": "Invalid trigger order bit range"
     },
     {
       "code": 6153,
@@ -9901,6 +9901,11 @@ export type Zeta = {
       "code": 6155,
       "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
       "msg": "Trigger order needs either a trigger price + direction, or trigger time"
+    },
+    {
+      "code": 6156,
+      "name": "TriggerOrderBitOccupied",
+      "msg": "Given trigger order bit is occupied, pick another"
     }
   ]
 };
@@ -19791,8 +19796,8 @@ export const IDL: Zeta = {
     },
     {
       "code": 6152,
-      "name": "InvalidTriggerOrderBit",
-      "msg": "Invalid trigger order index"
+      "name": "InvalidTriggerOrderBitRange",
+      "msg": "Invalid trigger order bit range"
     },
     {
       "code": 6153,
@@ -19808,6 +19813,11 @@ export const IDL: Zeta = {
       "code": 6155,
       "name": "TriggerOrderNeedsTimeOrPriceAndDirection",
       "msg": "Trigger order needs either a trigger price + direction, or trigger time"
+    },
+    {
+      "code": 6156,
+      "name": "TriggerOrderBitOccupied",
+      "msg": "Given trigger order bit is occupied, pick another"
     }
   ]
 };

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -3966,7 +3966,7 @@ export type Zeta = {
           "isSigner": false
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -3988,7 +3988,7 @@ export type Zeta = {
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         },
         {
@@ -4050,7 +4050,7 @@ export type Zeta = {
           "isSigner": false
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -4187,7 +4187,7 @@ export type Zeta = {
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         }
       ]
@@ -4211,7 +4211,7 @@ export type Zeta = {
           "isSigner": true
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -4223,7 +4223,7 @@ export type Zeta = {
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         }
       ]
@@ -4237,7 +4237,7 @@ export type Zeta = {
           "isSigner": true
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         }
@@ -6980,7 +6980,7 @@ export type Zeta = {
             }
           },
           {
-            "name": "triggerOrderIndexes",
+            "name": "triggerOrderBits",
             "type": "u128"
           },
           {
@@ -7105,7 +7105,7 @@ export type Zeta = {
       }
     },
     {
-      "name": "triggerOrderInfo",
+      "name": "triggerOrder",
       "type": {
         "kind": "struct",
         "fields": [
@@ -9852,13 +9852,18 @@ export type Zeta = {
     },
     {
       "code": 6152,
-      "name": "InvalidTriggerOrderIndex",
+      "name": "InvalidTriggerOrderBit",
       "msg": "Invalid trigger order index"
     },
     {
       "code": 6153,
       "name": "InvalidSecondaryAdmin",
       "msg": "Invalid secondary admin"
+    },
+    {
+      "code": 6154,
+      "name": "OnlyOwnerCanEditTriggerOrder",
+      "msg": "Only the owner can edit their own trigger order"
     }
   ]
 };
@@ -13831,7 +13836,7 @@ export const IDL: Zeta = {
           "isSigner": false
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -13853,7 +13858,7 @@ export const IDL: Zeta = {
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         },
         {
@@ -13915,7 +13920,7 @@ export const IDL: Zeta = {
           "isSigner": false
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -14052,7 +14057,7 @@ export const IDL: Zeta = {
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         }
       ]
@@ -14076,7 +14081,7 @@ export const IDL: Zeta = {
           "isSigner": true
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         },
@@ -14088,7 +14093,7 @@ export const IDL: Zeta = {
       ],
       "args": [
         {
-          "name": "triggerOrderIndex",
+          "name": "triggerOrderBit",
           "type": "u8"
         }
       ]
@@ -14102,7 +14107,7 @@ export const IDL: Zeta = {
           "isSigner": true
         },
         {
-          "name": "triggerOrderInfo",
+          "name": "triggerOrder",
           "isMut": true,
           "isSigner": false
         }
@@ -16845,7 +16850,7 @@ export const IDL: Zeta = {
             }
           },
           {
-            "name": "triggerOrderIndexes",
+            "name": "triggerOrderBits",
             "type": "u128"
           },
           {
@@ -16970,7 +16975,7 @@ export const IDL: Zeta = {
       }
     },
     {
-      "name": "triggerOrderInfo",
+      "name": "triggerOrder",
       "type": {
         "kind": "struct",
         "fields": [
@@ -19717,13 +19722,18 @@ export const IDL: Zeta = {
     },
     {
       "code": 6152,
-      "name": "InvalidTriggerOrderIndex",
+      "name": "InvalidTriggerOrderBit",
       "msg": "Invalid trigger order index"
     },
     {
       "code": 6153,
       "name": "InvalidSecondaryAdmin",
       "msg": "Invalid secondary admin"
+    },
+    {
+      "code": 6154,
+      "name": "OnlyOwnerCanEditTriggerOrder",
+      "msg": "Only the owner can edit their own trigger order"
     }
   ]
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -526,6 +526,21 @@ export function getSpreadAccount(
   );
 }
 
+export function getTriggerOrderInfo(
+  programId: PublicKey,
+  marginAccount: PublicKey,
+  triggerOrderIndex: Uint8Array
+): [PublicKey, number] {
+  return anchor.web3.PublicKey.findProgramAddressSync(
+    [
+      Buffer.from(anchor.utils.bytes.utf8.encode("trigger-order-info")),
+      marginAccount.toBuffer(),
+      triggerOrderIndex,
+    ],
+    programId
+  );
+}
+
 export function getMarketUninitialized(
   programId: PublicKey,
   zetaGroup: PublicKey,
@@ -1592,6 +1607,30 @@ export async function applyPerpFunding(asset: Asset, keys: PublicKey[]) {
       let txSig = await processTransaction(Exchange.provider, tx);
     })
   );
+}
+
+export async function executeTriggerOrder(
+  asset: Asset,
+  side: types.Side,
+  triggerOrderIndex: number,
+  triggerOrderInfo: PublicKey,
+  marginAccount: PublicKey,
+  openOrders: PublicKey,
+  whitelistTradingFeesAccount: PublicKey | undefined
+) {
+  let tx = new Transaction().add(
+    instructions.executeTriggerOrderIx(
+      asset,
+      side,
+      triggerOrderIndex,
+      triggerOrderInfo,
+      marginAccount,
+      openOrders,
+      whitelistTradingFeesAccount
+    )
+  );
+
+  await processTransaction(Exchange.provider, tx);
 }
 
 export function getProductLedger(marginAccount: MarginAccount, index: number) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1615,8 +1615,7 @@ export async function executeTriggerOrder(
   triggerOrderBit: number,
   triggerOrder: PublicKey,
   marginAccount: PublicKey,
-  openOrders: PublicKey,
-  whitelistTradingFeesAccount: PublicKey | undefined
+  openOrders: PublicKey
 ) {
   let tx = new Transaction().add(
     instructions.executeTriggerOrderIx(
@@ -1625,8 +1624,7 @@ export async function executeTriggerOrder(
       triggerOrderBit,
       triggerOrder,
       marginAccount,
-      openOrders,
-      whitelistTradingFeesAccount
+      openOrders
     )
   );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -526,16 +526,16 @@ export function getSpreadAccount(
   );
 }
 
-export function getTriggerOrderInfo(
+export function getTriggerOrder(
   programId: PublicKey,
   marginAccount: PublicKey,
-  triggerOrderIndex: Uint8Array
+  triggerOrderBit: Uint8Array
 ): [PublicKey, number] {
   return anchor.web3.PublicKey.findProgramAddressSync(
     [
-      Buffer.from(anchor.utils.bytes.utf8.encode("trigger-order-info")),
+      Buffer.from(anchor.utils.bytes.utf8.encode("trigger-order")),
       marginAccount.toBuffer(),
-      triggerOrderIndex,
+      triggerOrderBit,
     ],
     programId
   );
@@ -1612,8 +1612,8 @@ export async function applyPerpFunding(asset: Asset, keys: PublicKey[]) {
 export async function executeTriggerOrder(
   asset: Asset,
   side: types.Side,
-  triggerOrderIndex: number,
-  triggerOrderInfo: PublicKey,
+  triggerOrderBit: number,
+  triggerOrder: PublicKey,
   marginAccount: PublicKey,
   openOrders: PublicKey,
   whitelistTradingFeesAccount: PublicKey | undefined
@@ -1622,8 +1622,8 @@ export async function executeTriggerOrder(
     instructions.executeTriggerOrderIx(
       asset,
       side,
-      triggerOrderIndex,
-      triggerOrderInfo,
+      triggerOrderBit,
+      triggerOrder,
       marginAccount,
       openOrders,
       whitelistTradingFeesAccount


### PR DESCRIPTION
This PR implements trigger orders, which will be utilised for stop-loss/take-profit functionality. 

Functionality defaults to `FillOrKill` with trigger direction acting as a stop-loss/take-profit order (`INCREASING` if Ask, `DECREASING` if Bid), but you can use any order type and direction you wish to create more complicated things such as stop-limit orders.

Trigger price and order price are separate - as we don't have market order functionality in the program it's probably best to do `orderPrice = triggerPrice + slippage`, unless manually specified otherwise.

Trigger orders expire after `State.triggerOrderTimeoutSeconds`, and they can be deleted by an admin or the owner. They can also be edited by the owner (just the asset cannot be changed).