### PR TITLE
getMaxTradeSize(), getLiquidationPrice() and uPnL overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
-## [1.5.1] 2023-07-25
+## [1.6.0] 2023-07-25
 
 - Add getMaxTradeSize() and getLiquidationPrice() to risk calcs. ([#252](https://github.com/zetamarkets/sdk/pull/252))
+- Reformat pnl into estimateRealizedPnl() and calculateUnrealizedPnl(), using function overloads ([#252](https://github.com/zetamarkets/sdk/pull/252))
 
 ## [1.5.0] 2023-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version changes are pinned to SDK releases.
 
 - Add getMaxTradeSize() and getLiquidationPrice() to risk calcs. ([#252](https://github.com/zetamarkets/sdk/pull/252))
 - Reformat pnl into estimateRealizedPnl() and calculateUnrealizedPnl(), using function overloads ([#252](https://github.com/zetamarkets/sdk/pull/252))
+- Add checkLiquidity() util function to find the best price in the orderbook for a given size. ([#252](https://github.com/zetamarkets/sdk/pull/252))
 
 ## [1.5.0] 2023-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.5.1] 2023-07-25
+
+- Add getMaxTradeSize() and getLiquidationPrice() to risk calcs. ([#252](https://github.com/zetamarkets/sdk/pull/252))
+
+## [1.5.0] 2023-07-24
+
 - Add header to event queue fetch. ([#250](https://github.com/zetamarkets/sdk/pull/250))
 
 ## [1.4.4] 2023-07-14

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -681,17 +681,9 @@ export class Client {
     }
   }
 
-  public getMarginAccountState(
-    asset: Asset,
-    pnlExecutionPrice: number = undefined,
-    pnlAddTakerFees: boolean = false
-  ): types.MarginAccountState {
-    let pnlExecutionPrices = new Map();
-    pnlExecutionPrices.set(asset, pnlExecutionPrice);
+  public getMarginAccountState(asset: Asset): types.MarginAccountState {
     return Exchange.riskCalculator.getMarginAccountState(
-      this.getSubClient(asset).marginAccount,
-      pnlExecutionPrices,
-      pnlAddTakerFees
+      this.getSubClient(asset).marginAccount
     );
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -686,9 +686,11 @@ export class Client {
     pnlExecutionPrice: number = undefined,
     pnlAddTakerFees: boolean = false
   ): types.MarginAccountState {
+    let pnlExecutionPrices = new Map();
+    pnlExecutionPrices.set(asset, pnlExecutionPrice);
     return Exchange.riskCalculator.getMarginAccountState(
       this.getSubClient(asset).marginAccount,
-      pnlExecutionPrice,
+      pnlExecutionPrices,
       pnlAddTakerFees
     );
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -100,6 +100,9 @@ export const CRANK_ACCOUNT_LIMIT = 12;
 export const CRANK_PERP_ACCOUNT_LIMIT = 10;
 export const MAX_MARKETS_TO_FETCH = 50;
 
+export const MIN_LOT_SIZE = 0.001;
+export const PERP_MARKET_ORDER_SPOT_SLIPPAGE = 0.02;
+
 // This is the most we can load per iteration without
 // hitting the rate limit.
 export const MARKET_LOAD_LIMIT = 12;

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -839,12 +839,12 @@ export class CrossClient {
   }
 
   public getAccountState(
-    pnlExecutionPrice: number = undefined,
+    pnlExecutionPrices: Map<Asset, number | undefined> = undefined,
     pnlAddTakerFees: boolean = false
   ): types.CrossMarginAccountState {
     return Exchange.riskCalculator.getCrossMarginAccountState(
       this._account,
-      pnlExecutionPrice,
+      pnlExecutionPrices,
       pnlAddTakerFees
     );
   }

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -838,15 +838,8 @@ export class CrossClient {
     );
   }
 
-  public getAccountState(
-    pnlExecutionPrices: Map<Asset, number | undefined> = undefined,
-    pnlAddTakerFees: boolean = false
-  ): types.CrossMarginAccountState {
-    return Exchange.riskCalculator.getCrossMarginAccountState(
-      this._account,
-      pnlExecutionPrices,
-      pnlAddTakerFees
-    );
+  public getAccountState(): types.CrossMarginAccountState {
+    return Exchange.riskCalculator.getCrossMarginAccountState(this._account);
   }
 
   /**

--- a/src/risk-utils.ts
+++ b/src/risk-utils.ts
@@ -147,9 +147,7 @@ export function checkMarginAccountMarginRequirement(
 ) {
   let pnl = Exchange.riskCalculator.calculateUnrealizedPnl(
     marginAccount,
-    types.ProgramAccountType.MarginAccount,
-    undefined,
-    false
+    types.ProgramAccountType.MarginAccount
   );
   let totalMaintenanceMargin =
     Exchange.riskCalculator.calculateTotalMaintenanceMargin(

--- a/src/risk-utils.ts
+++ b/src/risk-utils.ts
@@ -138,11 +138,14 @@ export function checkMarginAccountMarginRequirement(
 ) {
   let pnl = Exchange.riskCalculator.calculateUnrealizedPnl(
     marginAccount,
-    types.ProgramAccountType.MarginAccount
+    types.ProgramAccountType.MarginAccount,
+    undefined,
+    false
   );
   let totalMaintenanceMargin =
     Exchange.riskCalculator.calculateTotalMaintenanceMargin(
-      marginAccount
+      marginAccount,
+      types.ProgramAccountType.MarginAccount
     ) as number;
   let buffer = marginAccount.balance.toNumber() + pnl - totalMaintenanceMargin;
   return buffer > 0;

--- a/src/risk-utils.ts
+++ b/src/risk-utils.ts
@@ -13,6 +13,7 @@ export function collectRiskMaps(
   imMap: Map<Asset, Number>,
   imSCMap: Map<Asset, Number>,
   mmMap: Map<Asset, Number>,
+  mmioMap: Map<Asset, Number>,
   upnlMap: Map<Asset, Number>,
   unpaidFundingMap: Map<Asset, Number>
 ): Map<Asset, types.AssetRiskState> {
@@ -23,6 +24,7 @@ export function collectRiskMaps(
       initialMargin: imMap.get(a),
       initialMarginSkipConcession: imSCMap.get(a),
       maintenanceMargin: mmMap.get(a),
+      maintenanceMarginIncludingOrders: mmioMap.get(a),
       unrealizedPnl: upnlMap.get(a),
       unpaidFunding: unpaidFundingMap.get(a),
     });

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -568,7 +568,7 @@ export class RiskCalculator {
     let availableBalanceInitial: number =
       balance + upnlTotal + unpaidFundingTotal - imTotal;
     let availableBalanceWithdrawable: number =
-      balance + upnlTotal + unpaidFundingTotal - imSkipConcessionTotal;
+      balance + upnlTotal + unpaidFundingTotal;
     let availableBalanceMaintenance: number =
       balance + upnlTotal + unpaidFundingTotal - mmTotal;
     let availableBalanceMaintenanceIncludingOrders: number =

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -113,6 +113,15 @@ export class RiskCalculator {
     return sideMultiplier * openingSize;
   }
 
+  public calculateUnpaidFunding(
+    account: MarginAccount,
+    accountType: types.ProgramAccountType
+  ): number;
+  public calculateUnpaidFunding(
+    account: CrossMarginAccount,
+    accountType: types.ProgramAccountType
+  ): Map<Asset, number>;
+
   /**
    * Returns the unpaid funding for a given margin account.
    * @param account the user's spread (returns 0) or margin account.
@@ -121,7 +130,7 @@ export class RiskCalculator {
     account: any,
     accountType: types.ProgramAccountType = types.ProgramAccountType
       .MarginAccount
-  ): number | Map<Asset, number> {
+  ): any {
     // Spread accounts cannot hold perps and therefore have no unpaid funding
     if (accountType == types.ProgramAccountType.SpreadAccount) {
       return 0;
@@ -168,6 +177,18 @@ export class RiskCalculator {
     }
   }
 
+  public calculateUnrealizedPnl(
+    account: MarginAccount,
+    accountType: types.ProgramAccountType,
+    executionPrice: Map<Asset, number | undefined>,
+    addTakerFees: boolean
+  ): number;
+  public calculateUnrealizedPnl(
+    account: CrossMarginAccount,
+    accountType: types.ProgramAccountType,
+    executionPrice: Map<Asset, number | undefined>,
+    addTakerFees: boolean
+  ): Map<Asset, number>;
   /**
    * Returns the unrealized pnl for a given margin or spread account.
    * @param account the user's spread or margin account.
@@ -178,7 +199,7 @@ export class RiskCalculator {
       .MarginAccount,
     executionPrice: Map<Asset, number | undefined> = undefined,
     addTakerFees: boolean = false
-  ): number | Map<Asset, number> {
+  ): any {
     let pnl = 0;
 
     let i_list = [];
@@ -254,6 +275,16 @@ export class RiskCalculator {
     }
   }
 
+  public calculateTotalInitialMargin(
+    account: MarginAccount,
+    accountType: types.ProgramAccountType,
+    skipConcession: boolean
+  ): number;
+  public calculateTotalInitialMargin(
+    account: CrossMarginAccount,
+    accountType: types.ProgramAccountType,
+    skipConcession: boolean
+  ): Map<Asset, number>;
   /**
    * Returns the total initial margin requirement for a given account.
    * This includes initial margin on positions which is used for
@@ -265,7 +296,7 @@ export class RiskCalculator {
     accountType: types.ProgramAccountType = types.ProgramAccountType
       .MarginAccount,
     skipConcession: boolean = false
-  ): number | Map<Asset, number> {
+  ): any {
     // Margin account only has 1 asset, but for CrossMarginAccount we iterate through all assets
     let assetList =
       accountType == types.ProgramAccountType.MarginAccount
@@ -339,6 +370,14 @@ export class RiskCalculator {
     }
   }
 
+  public calculateTotalMaintenanceMargin(
+    account: MarginAccount,
+    accountType: types.ProgramAccountType
+  ): number;
+  public calculateTotalMaintenanceMargin(
+    account: CrossMarginAccount,
+    accountType: types.ProgramAccountType
+  ): Map<Asset, number>;
   /**
    * Returns the total maintenance margin requirement for a given account.
    * This only uses maintenance margin on positions and is used for
@@ -350,7 +389,7 @@ export class RiskCalculator {
     account: any,
     accountType: types.ProgramAccountType = types.ProgramAccountType
       .MarginAccount
-  ): number | Map<Asset, number> {
+  ): any {
     // Margin account only has 1 asset, but for CrossMarginAccount we iterate through all assets
     let assetList =
       accountType == types.ProgramAccountType.MarginAccount
@@ -389,6 +428,14 @@ export class RiskCalculator {
     }
   }
 
+  public calculateTotalMaintenanceMarginIncludingOrders(
+    account: MarginAccount,
+    accountType: types.ProgramAccountType
+  ): number;
+  public calculateTotalMaintenanceMarginIncludingOrders(
+    account: CrossMarginAccount,
+    accountType: types.ProgramAccountType
+  ): Map<Asset, number>;
   /**
    * Returns the total maintenance margin requirement for a given account including orders.
    * This calculates maintenance margin across all positions and orders.
@@ -480,7 +527,8 @@ export class RiskCalculator {
     ) as Map<Asset, number>;
     let initialMargin = this.calculateTotalInitialMargin(
       marginAccount,
-      accType
+      accType,
+      false
     ) as Map<Asset, number>;
     let initialMarginSkipConcession = this.calculateTotalInitialMargin(
       marginAccount,
@@ -564,9 +612,14 @@ export class RiskCalculator {
       pnlExecutionPrice,
       pnlAddTakerFees
     ) as number;
-    let unpaidFunding = this.calculateUnpaidFunding(marginAccount) as number;
+    let unpaidFunding = this.calculateUnpaidFunding(
+      marginAccount,
+      types.ProgramAccountType.MarginAccount
+    ) as number;
     let initialMargin = this.calculateTotalInitialMargin(
-      marginAccount
+      marginAccount,
+      types.ProgramAccountType.MarginAccount,
+      false
     ) as number;
     let initialMarginSkipConcession = this.calculateTotalInitialMargin(
       marginAccount,
@@ -574,7 +627,8 @@ export class RiskCalculator {
       true
     ) as number;
     let maintenanceMargin = this.calculateTotalMaintenanceMargin(
-      marginAccount
+      marginAccount,
+      types.ProgramAccountType.MarginAccount
     ) as number;
     let availableBalanceInitial: number =
       balance + unrealizedPnl + unpaidFunding - initialMargin;

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -655,7 +655,6 @@ export class RiskCalculator {
     tradeSide: types.Side,
     tradePrice: number,
     bufferPercent: number = 5,
-    executionPrices: Map<Asset, number | undefined> = undefined,
     addTakerFees: boolean = false
   ): number {
     let stateMarkPrice = this.getCrossMarginAccountState(
@@ -663,6 +662,9 @@ export class RiskCalculator {
       undefined, // uPnL for margin calcs uses mark price
       addTakerFees
     );
+
+    let executionPrices = new Map();
+    executionPrices.set(tradeAsset, tradePrice);
 
     let stateExecutionPrice = this.getCrossMarginAccountState(
       marginAccount,

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -639,10 +639,6 @@ export class RiskCalculator {
     let openSize =
       stateMarkPrice.availableBalanceInitial /
       (init * markPrice + fee - extraUPNLPerLot);
-    console.log("openSize", openSize);
-    console.log(
-      `${stateMarkPrice.availableBalanceInitial} / ${init} * ${markPrice} + ${fee} - ${extraUPNLPerLot}`
-    );
 
     // (currentBalance + currentUPNL + unpaid funding - currentMMIO) + extraMMIO - fees > 0
     // stateExecutionPrice.availableBalanceMaintenanceIncludingOrders + extraMMIO - fees > 0
@@ -658,11 +654,6 @@ export class RiskCalculator {
       closeSize = positionAbs;
     }
 
-    console.log("closeSize", closeSize);
-    console.log(
-      `${stateExecutionPrice.availableBalanceMaintenanceIncludingOrders} / ${fee} - ${maint} * ${markPrice}`
-    );
-
     // (currentBalance + currentUPNL + unpaid funding - currentIM) + extraIMClose - extraIMOpen + extraUPNLOpen - fees > 0
     // stateExecutionPrice.availableBalanceInitial + extraIMClose - extraIMOpen + extraUPNLOpen - fees > 0
     // Where X is the number of extra lots opened on the other side:
@@ -677,10 +668,6 @@ export class RiskCalculator {
           positionAbs * init * markPrice) /
           (init * markPrice + fee - extraUPNLPerLot);
     }
-    console.log("closeOpenSize", closeOpenSize);
-    console.log(
-      `${stateExecutionPrice.availableBalanceInitial} + ${positionAbs} * ${init} * ${markPrice} / ${init} * ${markPrice} + ${fee} - ${extraUPNLPerLot}`
-    );
 
     if (
       position == 0 ||

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -9,7 +9,11 @@ import {
 import { assetToIndex, fromProgramAsset } from "./assets";
 import { Asset } from "./constants";
 import { assets, Decimal } from ".";
-import { calculateProductMargin, collectRiskMaps } from "./risk-utils";
+import {
+  calculateLiquidationPrice,
+  calculateProductMargin,
+  collectRiskMaps,
+} from "./risk-utils";
 
 export class RiskCalculator {
   private _marginRequirements: Map<Asset, Array<types.MarginRequirement>>;
@@ -682,5 +686,20 @@ export class RiskCalculator {
       // Return the one that gives the biggest size
       return Math.max(((100 - bufferPercent) / 100) * closeOpenSize, closeSize);
     }
+  }
+
+  public getLiquidationPrice(
+    asset: Asset,
+    signedPosition: number,
+    marginAccount: CrossMarginAccount
+  ) {
+    let state = this.getCrossMarginAccountState(marginAccount);
+    return calculateLiquidationPrice(
+      state.balance,
+      state.maintenanceMarginTotal,
+      state.unrealizedPnlTotal,
+      Exchange.getMarkPrice(asset),
+      signedPosition
+    );
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,6 +228,7 @@ export interface CrossMarginAccountState {
   initialMarginTotal: number;
   initalMarginSkipConcessionTotal: number;
   maintenanceMarginTotal: number;
+  maintenanceMarginIncludingOrdersTotal: number;
   unrealizedPnlTotal: number;
   unpaidFundingTotal: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,7 @@ export interface AssetRiskState {
   initialMargin: number;
   initialMarginSkipConcession: number;
   maintenanceMargin: number;
+  maintenanceMarginIncludingOrders: number;
   unrealizedPnl: number;
   unpaidFunding: number;
 }
@@ -221,6 +222,7 @@ export interface CrossMarginAccountState {
   balance: number;
   availableBalanceInitial: number;
   availableBalanceMaintenance: number;
+  availableBalanceMaintenanceIncludingOrders: number;
   availableBalanceWithdrawable: number;
   assetState: Map<Asset, AssetRiskState>;
   initialMarginTotal: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,12 @@ export function toProductKind(kind: Object): Kind {
   throw Error("Invalid product type");
 }
 
+export interface LiquidityCheckInfo {
+  validLiquidity: boolean;
+  avgPrice: number;
+  worstPrice: number;
+}
+
 export interface Order {
   marketIndex: number;
   market: PublicKey;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1714,7 +1714,7 @@ export function median(arr: number[]): number | undefined {
 export const checkLiquidity = (
   size: number,
   asset: Asset,
-  orderbook?: types.DepthOrderbook
+  orderbook: types.DepthOrderbook
 ): types.LiquidityCheckInfo => {
   const side = size > 0 ? types.Side.BID : types.Side.ASK;
   // We default to min lot size to still show a price


### PR DESCRIPTION
- getMaxTradeSize() - figures out the maximum size you can trade based on if you're closing or opening a position.
- getLiquidationPrice() - figures out at what price your position will get liquidated.
- Split uPnL calcs into estimateRealizedPnl() and calculateUnrealizedPnl()
- checkLiquidity() - finds the best price to execute an order at