### PR TITLE
Clamp calculatePnl execution size instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.7.4] 2023-08-28
+
+- Clamp executionInfo.size in calculatePnl() instead of throwing and error. ([#261](https://github.com/zetamarkets/sdk/pull/261))
+
 ## [1.7.3] 2023-08-28
 
 - Small bugfix for sizeUpperBound in getMaxTradeSize(). ([#260](https://github.com/zetamarkets/sdk/pull/260))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Caused some friction in FE so we don't want it to throw hard, instead just log out a warning and clamp to the min/max size.