### PR TITLE
Cancel all trigger orders + place order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.8.1] 2023-09-05
+
+- New function to cancel all trigger orders + place order. ([#265](https://github.com/zetamarkets/sdk/pull/265))
+
 ## [1.8.1] 2023-09-01
 
 - Default reduceOnly to true in trigger orders. ([#263](https://github.com/zetamarkets/sdk/pull/263))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -85,6 +85,7 @@ export const MAX_SETTLE_AND_CLOSE_PER_TX = 4;
 export const MAX_CANCELS_PER_TX = 3;
 export const MAX_CANCELS_PER_TX_LUT = 13;
 export const MAX_GREEK_UPDATES_PER_TX = 20;
+export const MAX_TRIGGER_CANCELS_PER_TX = 10;
 export const MAX_SETTLEMENT_ACCOUNTS = 20;
 export const MAX_FUNDING_ACCOUNTS = 20;
 export const MAX_REBALANCE_ACCOUNTS = 18;

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -1292,7 +1292,7 @@ export class CrossClient {
       let tx = new Transaction();
       for (var j = 0; j < constants.MAX_TRIGGER_CANCELS_PER_TX; j++) {
         // Don't want to overrun on the last one
-        if (i + j >= triggerOrderIndexes.length) {
+        if (i + j >= indexes.length) {
           break;
         }
         let triggerAccount = utils.getTriggerOrder(


### PR DESCRIPTION
Useful for FE when closing positions. Cancel all trigger orders for a given asset and then place one order on the same asset.

Tested locally in the following conditions:
- 55 trigger orders active -> completes in 6 txs
- 5 trigger orders active -> completes in 1 tx
- 0 trigger orders active -> completes in 1 tx