### PR TITLE
Add auto prio fee offset and multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.9.1] 2023-09-11
+
+- Add auto prio fee offset and multiplier. ([#269](https://github.com/zetamarkets/sdk/pull/269))
+
 ## [1.9.0] 2023-09-07
 
 - Add margin account pubkeys to LiquidationEvent. ([#268](https://github.com/zetamarkets/sdk/pull/268))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -288,6 +288,9 @@ export class Exchange {
   }
   private _useAutoPriorityFee: boolean = false;
 
+  private _autoPriorityFeeOffset: number = 0;
+  private _autoPriorityFeeMultiplier: number = 1;
+
   // Micro lamports per CU of fees.
   public get autoPriorityFeeUpperLimit(): number {
     return this._autoPriorityFeeUpperLimit;
@@ -302,6 +305,11 @@ export class Exchange {
 
   public toggleAutoPriorityFee() {
     this._useAutoPriorityFee = !this._useAutoPriorityFee;
+  }
+
+  public setAutoPriorityFeeScaling(offset: number = 0, multiplier: number = 1) {
+    this._autoPriorityFeeMultiplier = multiplier;
+    this._autoPriorityFeeOffset = offset;
   }
 
   public updatePriorityFee(microLamportsPerCU: number) {
@@ -667,7 +675,12 @@ export class Exchange {
         .map((obj) => obj.prioritizationFee); // Take a list of prioritizationFee values only
 
       let median = utils.median(fees);
-      this._priorityFee = Math.min(median, this._autoPriorityFeeUpperLimit);
+      let medianScaled =
+        this._autoPriorityFeeOffset + median * this._autoPriorityFeeMultiplier;
+      this._priorityFee = Math.min(
+        medianScaled,
+        this._autoPriorityFeeUpperLimit
+      );
       console.log(
         `AutoUpdate priority fee. New fee = ${this._priorityFee} microlamports per compute unit`
       );


### PR DESCRIPTION
Useful for FE to scale prio fees as none/low/high, this PR adds an optional offset and multiplier to the auto fees