### PR TITLE
Better handling for empty account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.10.5] 2023-09-25
+
+- Bugfix: Handle empty accounts better to prevent undefined issues with trigger orders. ([#277](https://github.com/zetamarkets/sdk/pull/277))
+
 ## [1.10.4] 2023-09-19
 
 - Bugfix: Fix loading order to prevent a rarely occurring market undefined error. ([#274](https://github.com/zetamarkets/sdk/pull/274))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -266,6 +266,7 @@ export class CrossClient {
 
     this._positions = new Map();
     this._orders = new Map();
+    this._triggerOrders = new Map();
     for (var asset of Exchange.assets) {
       this._positions.set(asset, []);
       this._orders.set(asset, []);
@@ -1070,6 +1071,10 @@ export class CrossClient {
   }
 
   public findAvailableTriggerOrderBit(): number {
+    // If we haven't loaded properly for whatever reason just use the last index to minimise the chance of collisions
+    if (!this.account || !this.account.triggerOrderBits) {
+      return 127;
+    }
     for (var i = 0; i < 128; i++) {
       let mask: BN = new BN(1).shln(i); // 1 << i
       if (this.account.triggerOrderBits.and(mask).isZero()) {
@@ -2407,6 +2412,9 @@ export class CrossClient {
 
   public async updateOrders() {
     this.updateOpenOrdersSync();
+    if (!this.account || !this.account.triggerOrderBits) {
+      return;
+    }
 
     let triggerOrderBits = [];
 


### PR DESCRIPTION
Small fix to stop undefined errors when the account is empty and we're checking trigger orders