### PR TITLE
ZSTD compression for RPC websocket connections 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.11.3] 2023-11-02
+
+- Use fork of web3.js to enable zstd compression across the SDK. Reduces network usage significantly. ([#290](https://github.com/zetamarkets/sdk/pull/290))
+
 ## [1.11.2] 2023-10-24
 
 - Add price to TradeEventV3. ([#288](https://github.com/zetamarkets/sdk/pull/288))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.11.2",
+  "version": "1.11.4",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -13,21 +13,22 @@
     "build-no-idl": "./node_modules/.bin/tsc"
   },
   "dependencies": {
-    "@zetamarkets/anchor": "0.26.0-versioned",
     "@solana/buffer-layout": "4.0.0",
     "@solana/spl-token": "0.1.6",
-    "@solana/web3.js": "1.68.0",
+    "@solana/web3.js": "1.87.3",
+    "@zetamarkets/anchor": "0.26.1-versioned",
     "bs58": "^4.0.1",
-    "lodash": "^4.17.21",
     "cross-fetch": "^3.1.6",
-    "lodash.clonedeep": "^4.5.0"
+    "lodash": "^4.17.21",
+    "lodash.clonedeep": "^4.5.0",
+    "zeta-solana-web3": "1.87.7"
   },
   "devDependencies": {
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.12",
     "mocha": "^9.1.1",
-    "typedoc": "^0.22.10",
     "ts-node": "^10.7.0",
+    "typedoc": "^0.22.10",
     "typescript": "^4.4.2"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.11.4",
+  "version": "1.11.3",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -22,15 +22,16 @@ import {
 } from "./program-types";
 import {
   PublicKey,
-  Connection,
   Transaction,
   TransactionSignature,
   AccountInfo,
   Context,
+  Connection,
   TransactionInstruction,
   ConfirmOptions,
   SYSVAR_CLOCK_PUBKEY,
 } from "@solana/web3.js";
+import { PublicKey as PublicKeyZstd } from "zeta-solana-web3";
 import * as types from "./types";
 import * as instructions from "./program-instructions";
 import { EventType } from "./events";
@@ -523,8 +524,8 @@ export class CrossClient {
       try {
         let [clockInfo, crossMarginAccountInfo] =
           await Exchange.connection.getMultipleAccountsInfo([
-            SYSVAR_CLOCK_PUBKEY,
-            this._accountAddress,
+            SYSVAR_CLOCK_PUBKEY as PublicKeyZstd,
+            this._accountAddress as PublicKeyZstd,
           ]);
         fetchSlot = utils.getClockData(clockInfo).slot;
         this._account = Exchange.program.coder.accounts.decode(
@@ -2090,7 +2091,7 @@ export class CrossClient {
     side: types.Side
   ): Promise<TransactionSignature> {
     let accountInfo = await Exchange.connection.getAccountInfo(
-      marginAccountToCancel
+      marginAccountToCancel as PublicKeyZstd
     );
 
     let account: programTypes.MarginAccount | programTypes.CrossMarginAccount;
@@ -2151,7 +2152,7 @@ export class CrossClient {
     marginAccountToCancel: PublicKey
   ): Promise<TransactionSignature> {
     let accountInfo = await Exchange.connection.getAccountInfo(
-      marginAccountToCancel
+      marginAccountToCancel as PublicKeyZstd
     );
 
     let account: programTypes.MarginAccount | programTypes.CrossMarginAccount;

--- a/src/market.ts
+++ b/src/market.ts
@@ -6,6 +6,10 @@ import {
   Context,
   PublicKey,
 } from "@solana/web3.js";
+import {
+  Connection as ConnectionZstd,
+  PublicKey as PublicKeyZstd,
+} from "zeta-solana-web3";
 import { exchange as Exchange } from "./exchange";
 import * as constants from "./constants";
 import {
@@ -90,17 +94,17 @@ export class ZetaGroupMarkets {
           commitment: opts.commitment,
           skipPreflight: opts.skipPreflight,
         },
-        constants.DEX_PID[Exchange.network]
+        constants.DEX_PID[Exchange.network] as PublicKeyZstd
       );
     } else {
       serumMarket = await SerumMarket.load(
         Exchange.connection,
-        marketAddr,
+        marketAddr as PublicKeyZstd,
         {
           commitment: opts.commitment,
           skipPreflight: opts.skipPreflight,
         },
-        constants.DEX_PID[Exchange.network]
+        constants.DEX_PID[Exchange.network] as PublicKeyZstd
       );
     }
 
@@ -122,7 +126,9 @@ export class ZetaGroupMarkets {
       serumMarket
     );
 
-    let book = await serumMarket.loadBidsAndAsks(Exchange.provider.connection);
+    let book = await serumMarket.loadBidsAndAsks(
+      Exchange.provider.connection as unknown as ConnectionZstd
+    );
     instance._market.bids = book.bids;
     instance._market.asks = book.asks;
     instance._market.updateOrderbook();

--- a/src/serum/market.ts
+++ b/src/serum/market.ts
@@ -6,10 +6,10 @@ import {
   Account,
   AccountInfo,
   Commitment,
-  Connection,
-  PublicKey,
+  PublicKey as PublicKeySolana,
   SYSVAR_CLOCK_PUBKEY,
 } from "@solana/web3.js";
+import { Connection, PublicKey } from "zeta-solana-web3";
 import { decodeEventQueue, decodeRequestQueue } from "./queue";
 import { Buffer } from "buffer";
 import { exchange as Exchange } from "../exchange";
@@ -518,7 +518,7 @@ export class Orderbook {
 
 export interface Order {
   orderId: BN;
-  openOrdersAddress: PublicKey;
+  openOrdersAddress: PublicKeySolana;
   openOrdersSlot: number;
   price: number;
   priceLots: BN;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import {
   Transaction,
   VersionedTransaction,
 } from "@solana/web3.js";
+import { Connection as ConnectionZstd } from "zeta-solana-web3";
 import { allAssets } from "./assets";
 import { Asset } from "./constants";
 import { objectEquals } from "./utils";
@@ -465,7 +466,7 @@ export function defaultOrderOptions(): OrderOptions {
 export interface LoadExchangeConfig {
   network: Network;
   connection: Connection;
-  orderbookConnection?: Connection;
+  orderbookConnection?: Connection | ConnectionZstd;
   orderbookAssetSubscriptionOverride?: Asset[];
   opts: ConfirmOptions;
   throttleMs: number;


### PR DESCRIPTION
@solana/web3.js doesn't support different encodings so I made a fork: https://github.com/zetamarkets/zeta-solana-web3.js. It essentially just adds some code into connection.ts to seamlessly allow both base64 and base64+zstd encodings.

This PR allows for the use of a Connection object from that fork, and defaults everything to using `base64+zstd` for the encoding. CPU usage is minimally increased but network usage is 5-10x lower.