### PR TITLE
Add new TIF buffer option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.11.6] 2023-11-06
+
+- Add new TIF buffer option ([#293](https://github.com/zetamarkets/sdk/pull/293))
+
 ## [1.11.5] 2023-11-02
 
 - Remove default trigger direction in editPriceTriggerOrder. ([#291](https://github.com/zetamarkets/sdk/pull/291))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -2410,13 +2410,15 @@ export class CrossClient {
         order.orderId,
         order.side == types.Side.BID
       );
-      let serumMarket = Exchange.getPerpMarket(order.asset).serumMarket;
+      let market = Exchange.getPerpMarket(order.asset);
+      let serumMarket = market.serumMarket;
 
       return !utils.isOrderExpired(
         order.tifOffset,
         seqNum,
         serumMarket.epochStartTs.toNumber(),
-        serumMarket.startEpochSeqNum
+        serumMarket.startEpochSeqNum,
+        market.TIFBufferSeconds
       );
     });
     let ordersByAsset = new Map();

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -666,6 +666,11 @@ export class Exchange {
         (loadConfig.orderbookAssetSubscriptionOverride &&
           loadConfig.orderbookAssetSubscriptionOverride.includes(se.asset))
       ) {
+        // Optionally provide a buffer for when orders are not shown due to TIF
+        // Useful for slow internet connections on FE because it doesn't have to be exactly precise
+        if (loadConfig.TIFBufferSeconds) {
+          se.markets.market.TIFBufferSeconds = loadConfig.TIFBufferSeconds;
+        }
         se.markets.market.subscribeOrderbook(callback);
       }
       this._zetaGroupPubkeyToAsset.set(se.zetaGroupAddress, se.asset);

--- a/src/market.ts
+++ b/src/market.ts
@@ -251,6 +251,14 @@ export class Market {
   }
   private _strike: number;
 
+  public set TIFBufferSeconds(buffer: number) {
+    this._TIFBufferSeconds = buffer;
+  }
+  public get TIFBufferSeconds(): number {
+    return this._TIFBufferSeconds;
+  }
+  private _TIFBufferSeconds: number;
+
   public constructor(
     asset: Asset,
     address: PublicKey,
@@ -269,6 +277,7 @@ export class Market {
     this._orderbook = { bids: [], asks: [] };
     this._bidsSlot = 0;
     this._asksSlot = 0;
+    this._TIFBufferSeconds = 0;
   }
 
   public updateStrike() {
@@ -372,7 +381,8 @@ export class Market {
             tifOffset.toNumber(),
             seqNum,
             this._serumMarket.epochStartTs.toNumber(),
-            this._serumMarket.startEpochSeqNum
+            this._serumMarket.startEpochSeqNum,
+            this._TIFBufferSeconds
           )
         ) {
           continue;

--- a/src/serum/scripts/market-gen.ts
+++ b/src/serum/scripts/market-gen.ts
@@ -26,6 +26,7 @@ const main = async () => {
       opts: utils.defaultCommitment(),
       throttleMs: 0,
       loadFromStore: false,
+      TIFBufferSeconds: 0,
     };
 
     await Exchange.load(LOAD_CONFIG);

--- a/src/subclient.ts
+++ b/src/subclient.ts
@@ -1396,13 +1396,15 @@ export class SubClient {
         order.orderId,
         order.side == types.Side.BID
       );
-      let serumMarket = Exchange.getPerpMarket(asset).serumMarket;
+      let market = Exchange.getPerpMarket(asset);
+      let serumMarket = market.serumMarket;
 
       return !utils.isOrderExpired(
         order.tifOffset,
         seqNum,
         serumMarket.epochStartTs.toNumber(),
-        serumMarket.startEpochSeqNum
+        serumMarket.startEpochSeqNum,
+        market.TIFBufferSeconds
       );
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -471,6 +471,7 @@ export interface LoadExchangeConfig {
   opts: ConfirmOptions;
   throttleMs: number;
   loadFromStore: boolean;
+  TIFBufferSeconds: number;
 }
 
 export function defaultLoadExchangeConfig(
@@ -480,7 +481,8 @@ export function defaultLoadExchangeConfig(
   throttleMs = 0,
   loadFromStore = false,
   orderbookConnection: Connection = undefined,
-  orderbookAssetSubscriptionOverride: Asset[] = undefined
+  orderbookAssetSubscriptionOverride: Asset[] = undefined,
+  TIFBufferSeconds: number = undefined
 ): LoadExchangeConfig {
   return {
     network,
@@ -490,6 +492,7 @@ export function defaultLoadExchangeConfig(
     opts,
     throttleMs,
     loadFromStore,
+    TIFBufferSeconds,
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1716,13 +1716,17 @@ export function isOrderExpired(
   orderTIFOffset: number,
   orderSeqNum: anchor.BN,
   epochStartTs: number,
-  startEpochSeqNum: anchor.BN
+  startEpochSeqNum: anchor.BN,
+  TIFBufferSeconds: number
 ): boolean {
   if (orderTIFOffset == 0) {
     return false;
   }
 
-  if (epochStartTs + orderTIFOffset < Exchange.clockTimestamp) {
+  if (
+    epochStartTs + orderTIFOffset <
+    Exchange.clockTimestamp - TIFBufferSeconds
+  ) {
     return true;
   }
 


### PR DESCRIPTION
Optionally provide a buffer for when orders are not shown due to TIF. This is useful for slow internet connections on FE because it doesn't have to be exactly precise, and we'd prefer a consistent orderbook that doesn't cut out.