### PR TITLE
Round priority fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.11.7] 2023-11-06
+
+- Round priority fees to the nearest integer ([#294](https://github.com/zetamarkets/sdk/pull/294))
+
 ## [1.11.6] 2023-11-06
 
 - Add new TIF buffer option ([#293](https://github.com/zetamarkets/sdk/pull/293))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.11.6",
+  "version": "1.11.7",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -732,9 +732,8 @@ export class Exchange {
       let median = utils.median(fees);
       let medianScaled =
         this._autoPriorityFeeOffset + median * this._autoPriorityFeeMultiplier;
-      this._priorityFee = Math.min(
-        medianScaled,
-        this._autoPriorityFeeUpperLimit
+      this._priorityFee = Math.round(
+        Math.min(medianScaled, this._autoPriorityFeeUpperLimit)
       );
       console.log(
         `AutoUpdate priority fee. New fee = ${this._priorityFee} microlamports per compute unit`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -898,7 +898,7 @@ export async function processTransaction(
   if (Exchange.priorityFee != 0) {
     tx.instructions.unshift(
       ComputeBudgetProgram.setComputeUnitPrice({
-        microLamports: Exchange.priorityFee,
+        microLamports: Math.round(Exchange.priorityFee),
       })
     );
   }


### PR DESCRIPTION
Saw some errors like `The number 262.5 cannot be converted to a BigInt because it is not an integer` because we had decimal prio fees. This PR adds rounding to both the auto fee we fetch and also the fee we actually send, in case someone puts a decimal fee manually.