### PR TITLE
Permissionless account creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.11.7",
+  "version": "1.12.0",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -262,7 +262,7 @@
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",
@@ -334,7 +334,7 @@
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": true
         },
         {
           "name": "payer",

--- a/src/idl/zeta.json
+++ b/src/idl/zeta.json
@@ -298,7 +298,7 @@
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",
@@ -334,7 +334,7 @@
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -298,7 +298,7 @@ export type Zeta = {
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",
@@ -334,7 +334,7 @@ export type Zeta = {
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",
@@ -10537,7 +10537,7 @@ export const IDL: Zeta = {
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",
@@ -10573,7 +10573,7 @@ export const IDL: Zeta = {
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",

--- a/src/types/zeta.ts
+++ b/src/types/zeta.ts
@@ -262,7 +262,7 @@ export type Zeta = {
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",
@@ -334,7 +334,7 @@ export type Zeta = {
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": true
         },
         {
           "name": "payer",
@@ -10501,7 +10501,7 @@ export const IDL: Zeta = {
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": true
+          "isSigner": false
         },
         {
           "name": "payer",
@@ -10573,7 +10573,7 @@ export const IDL: Zeta = {
         {
           "name": "authority",
           "isMut": false,
-          "isSigner": false
+          "isSigner": true
         },
         {
           "name": "payer",


### PR DESCRIPTION
### BREAKING: THIS PR IS A BREAKING CHANGE TO THE ACCOUNT INITIALISATION INSTRUCTIONS

Remove the requirement for authority to be a signer, allowing CPI calls to be made more easily 😊 