### PR TITLE
Make order type a required arg for trigger orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.11.8]
+
+- Make orderType mandatory for trigger orders. ([#298](https://github.com/zetamarkets/sdk/pull/298))
 - Add a more precise estimate for liquidation price (under the assumption that other mark prices remain static). ([#296](https://github.com/zetamarkets/sdk/pull/296))
 
 ## [1.11.7] 2023-11-06

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.11.7",
+  "version": "1.11.8",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -1093,6 +1093,7 @@ export class CrossClient {
     triggerTime: anchor.BN,
     size: number,
     side: types.Side,
+    orderType: types.OrderType,
     options: types.TriggerOrderOptions = types.defaultTriggerOrderOptions()
   ): Promise<TransactionSignature> {
     return await this.placeTriggerOrder(
@@ -1103,6 +1104,7 @@ export class CrossClient {
       0,
       types.TriggerDirection.UNINITIALIZED,
       triggerTime,
+      orderType,
       options
     );
   }
@@ -1114,6 +1116,7 @@ export class CrossClient {
     triggerPrice: number,
     size: number,
     side: types.Side,
+    orderType: types.OrderType,
     options: types.TriggerOrderOptions = types.defaultTriggerOrderOptions(),
     triggerDirection: types.TriggerDirection = types.getDefaultTriggerDirection(
       side
@@ -1127,6 +1130,7 @@ export class CrossClient {
       triggerPrice,
       triggerDirection,
       new anchor.BN(0),
+      orderType,
       options
     );
   }
@@ -1141,6 +1145,7 @@ export class CrossClient {
       side
     ),
     triggerTimestamp: anchor.BN,
+    orderType: types.OrderType,
     options: types.TriggerOrderOptions = types.defaultTriggerOrderOptions()
   ): Promise<TransactionSignature> {
     let triggerOrderBit = this.findAvailableTriggerOrderBit();
@@ -1178,9 +1183,7 @@ export class CrossClient {
         triggerOrderBit,
         size,
         side,
-        options.orderType != undefined
-          ? options.orderType
-          : types.OrderType.FILLORKILL,
+        orderType,
         options.reduceOnly != undefined ? options.reduceOnly : false,
         options.tag,
         this.accountAddress,
@@ -1376,6 +1379,7 @@ export class CrossClient {
     newTriggerTime: anchor.BN,
     newSize: number,
     newSide: types.Side,
+    newOrderType: types.OrderType,
     newOptions: types.TriggerOrderOptions = types.defaultTriggerOrderOptions()
   ) {
     await this.editTriggerOrder(
@@ -1386,6 +1390,7 @@ export class CrossClient {
       0,
       types.TriggerDirection.UNINITIALIZED,
       newTriggerTime,
+      newOrderType,
       newOptions
     );
   }
@@ -1397,6 +1402,7 @@ export class CrossClient {
     newSize: number,
     newSide: types.Side,
     newDirection: types.TriggerDirection,
+    newOrderType: types.OrderType,
     newOptions: types.TriggerOrderOptions = types.defaultTriggerOrderOptions()
   ) {
     await this.editTriggerOrder(
@@ -1407,6 +1413,7 @@ export class CrossClient {
       newTriggerPrice,
       newDirection,
       new anchor.BN(0),
+      newOrderType,
       newOptions
     );
   }
@@ -1419,6 +1426,7 @@ export class CrossClient {
     newTriggerPrice: number,
     newDirection: types.TriggerDirection,
     newTriggerTimestamp: anchor.BN,
+    newOrderType: types.OrderType,
     newOptions: types.TriggerOrderOptions = types.defaultTriggerOrderOptions()
   ) {
     let triggerAccount = utils.getTriggerOrder(
@@ -1434,9 +1442,7 @@ export class CrossClient {
         newTriggerTimestamp,
         newSize,
         newSide,
-        newOptions.orderType != undefined
-          ? newOptions.orderType
-          : types.OrderType.FILLORKILL,
+        newOrderType,
         newOptions.reduceOnly != undefined ? newOptions.reduceOnly : false,
         this._provider.wallet.publicKey,
         triggerAccount

--- a/src/types.ts
+++ b/src/types.ts
@@ -418,7 +418,6 @@ export interface OrderOptions {
 }
 
 export interface TriggerOrderOptions {
-  orderType?: types.OrderType;
   reduceOnly?: boolean;
   tag?: string;
   blockhash?: { blockhash: string; lastValidBlockHeight: number };
@@ -432,7 +431,6 @@ export function getDefaultTriggerDirection(side: Side): TriggerDirection {
 
 export function defaultTriggerOrderOptions(): TriggerOrderOptions {
   return {
-    orderType: OrderType.FILLORKILL,
     reduceOnly: true,
     tag: constants.DEFAULT_ORDER_TAG,
     blockhash: undefined,


### PR DESCRIPTION
Now that we're adding LIMIT order type for trigger orders, we should make the orderType param mandatory too 😊 