### PR TITLE
Reformat liquidation utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.11.9]
+
+- Add fake trade functionality to getEstimatedLiquidationPrice. ([#299](https://github.com/zetamarkets/sdk/pull/299))
+- Remove old functions getLiquidationPrice and calculateLiquidationPrice. ([#299](https://github.com/zetamarkets/sdk/pull/299))
+
 ## [1.11.8]
 
 - Make orderType mandatory for trigger orders. ([#298](https://github.com/zetamarkets/sdk/pull/298))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/risk-utils.ts
+++ b/src/risk-utils.ts
@@ -45,29 +45,6 @@ export function collectRiskMaps(
 }
 
 /**
- * Calculates the price at which a position will be liquidated.
- * @param accountBalance    margin account balance in decimal USDC
- * @param marginRequirement total margin requirement for margin account, in decimal USDC
- * @param unrealizedPnl     signed unrealized pnl for margin account, in decimal USDC
- * @param markPrice         mark price of product being calculated, in decimal USDC
- * @param position          signed position size of user, in decimal USDC
- * @returns Liquidation price, in decimal USDC
- */
-export function calculateLiquidationPrice(
-  accountBalance: number,
-  marginRequirement: number,
-  unrealizedPnl: number,
-  markPrice: number,
-  position: number
-): number {
-  if (position == 0) {
-    return 0;
-  }
-  let availableBalance = accountBalance - marginRequirement + unrealizedPnl;
-  return markPrice - availableBalance / position;
-}
-
-/**
  * Calculates the margin requirement for a given market.
  * @param asset         underlying asset (SOL, BTC, etc.)
  * @param spotPrice     price of the spot, in decimal USDC


### PR DESCRIPTION
- Add fake trade functionality to `getEstimatedLiquidationPrice` so that FE can use it for order entry calcs
- Remove old functions `getLiquidationPrice` and `calculateLiquidationPrice`