### PR TITLE
Bugfix getMaxTradeSize with leverage option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.12.2]
+
+- Bugfix getMaxTradeSize with leverage option. ([#300](https://github.com/zetamarkets/sdk/pull/300))
+
 ## [1.12.1]
 
-- Add optional override equity param in leverage util([#301](https://github.com/zetamarkets/sdk/pull/301))
+- Add optional override equity param in leverage util. ([#301](https://github.com/zetamarkets/sdk/pull/301))
 
 ## [1.12.0]
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.11.8",
+  "version": "1.11.9",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -998,11 +998,17 @@ export class RiskCalculator {
       // TODO if this is slow then do only the necessary calcs manually, there's a bunch of extra calcs in here
       // that aren't needed in getMaxTradeSize()
       let newState = this.getCrossMarginAccountState(editedAccount);
+      let nonLeverageBuffer =
+        newState.availableBalanceInitial / newState.balance;
       let buffer =
         maxLeverage == -1
           ? newState.availableBalanceInitial / newState.balance
-          : (maxLeverage - this.getLeverage(editedAccount, undefined, false)) /
-            maxLeverage;
+          : Math.min(
+              (maxLeverage -
+                this.getLeverage(editedAccount, undefined, false)) /
+                maxLeverage,
+              nonLeverageBuffer
+            );
 
       if (
         buffer < thresholdPercent / 100 &&


### PR DESCRIPTION
Setting maxLeverage allowed an unintended override to the trade size buffer if you had open orders, just add a Math.min() to patch this