### PR TITLE
Override equity param in leverage util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.12.1]
+
+- Add optional override equity param in leverage util([#301](https://github.com/zetamarkets/sdk/pull/301))
+
 ## [1.12.0]
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -1226,12 +1226,14 @@ export class RiskCalculator {
    * @param marginAccount The CrossMarginAccount itself, edited in-place if executionInfo is provided
    * @param executionInfo (Optional) A hypothetical trade. Object containing: asset (Asset), price (decimal USDC), size (signed decimal), isTaker (whether or not it trades for full size)
    * @param clone Whether to deep-copy the marginAccount as part of the function. You can speed up execution by providing your own already deep-copied marginAccount if calling multiple risk.ts functions.
+   * @param overrideEquity whether to override the equity part of the calc, using the unchanged equity
    * @returns A decimal value representing the current leverage.
    */
   public getLeverage(
     marginAccount: CrossMarginAccount,
     executionInfo?: types.ExecutionInfo,
-    clone: boolean = true
+    clone: boolean = true,
+    overrideEquity: boolean = false
   ): number {
     if (marginAccount.balance.toNumber() == 0) return 0;
 
@@ -1253,6 +1255,11 @@ export class RiskCalculator {
         ) * Exchange.getMarkPrice(asset);
     }
 
-    return positionValue / this.getCrossMarginAccountState(account).equity;
+    return (
+      positionValue /
+      (overrideEquity
+        ? this.getCrossMarginAccountState(marginAccount).equity
+        : this.getCrossMarginAccountState(account).equity)
+    );
   }
 }


### PR DESCRIPTION
Useful for an edge case in FE, an optional value to use the original equity for getLeverage() instead of the new one from the trade