### PR TITLE
Add mark price override in getLeverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.12.3]
+
+- New override in getLeverage() to use executionInfo price as markPrice. ([#302](https://github.com/zetamarkets/sdk/pull/302))
+
 ## [1.12.2]
 
 - Bugfix getMaxTradeSize with leverage option. ([#300](https://github.com/zetamarkets/sdk/pull/300))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/risk-utils.ts
+++ b/src/risk-utils.ts
@@ -286,6 +286,8 @@ export function addFakeTradeToAccount(
 
   marginAccount.productLedgers[assetIndex].orderState = editedOrderState;
   marginAccount.productLedgers[assetIndex].position = editedPosition;
+  marginAccount.lastFundingDeltas[assetIndex] =
+    Exchange.pricing.fundingDeltas[assetIndex];
 }
 
 /**

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -954,7 +954,7 @@ export class RiskCalculator {
       Math.max(
         0,
         state.balance /
-          (init * 2 * Math.min(Exchange.getMarkPrice(tradeAsset), tradePrice))
+          (init * Math.min(Exchange.getMarkPrice(tradeAsset), tradePrice))
       );
     if (sizeUpperBound == 0) {
       return closeSize;

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -997,11 +997,12 @@ export class RiskCalculator {
       // TODO if this is slow then do only the necessary calcs manually, there's a bunch of extra calcs in here
       // that aren't needed in getMaxTradeSize()
       let newState = this.getCrossMarginAccountState(editedAccount);
+      let equity = newState.balance - newState.unpaidFundingTotal;
       let nonLeverageBuffer =
-        (newState.balance -
-          newState.unpaidFundingTotal -
+        (equity +
+          Math.min(newState.unrealizedPnlTotal, 0) -
           newState.initialMarginTotal) /
-        (newState.balance - newState.unpaidFundingTotal);
+        equity;
 
       let buffer =
         maxLeverage == -1
@@ -1028,7 +1029,9 @@ export class RiskCalculator {
             10 ** constants.POSITION_PRECISION
         );
       } else if (
-        (maxLeverage == -1 && newState.availableBalanceInitial < 0) ||
+        (maxLeverage == -1 &&
+          newState.initialMarginTotal >
+            equity + Math.min(newState.unrealizedPnlTotal, 0)) ||
         (maxLeverage != -1 && buffer < 0)
       ) {
         sizeUpperBound = size;

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -1038,7 +1038,8 @@ export class RiskCalculator {
         (maxLeverage == -1 &&
           newState.initialMarginTotal >
             equity + Math.min(newState.unrealizedPnlTotal, 0)) ||
-        (maxLeverage != -1 && buffer < 0)
+        (maxLeverage != -1 && buffer < 0) ||
+        buffer > 1
       ) {
         sizeUpperBound = size;
         size = (sizeLowerBound + size) / 2;

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -949,7 +949,13 @@ export class RiskCalculator {
 
     // Iterate until we find a good size using a binary search
     let sizeLowerBound = 0;
-    let sizeUpperBound = 2 * Math.max(0, state.balance / (init * tradePrice));
+    let sizeUpperBound =
+      2 *
+      Math.max(
+        0,
+        state.balance /
+          (init * 2 * Math.min(Exchange.getMarkPrice(tradeAsset), tradePrice))
+      );
     if (sizeUpperBound == 0) {
       return closeSize;
     }
@@ -1245,7 +1251,7 @@ export class RiskCalculator {
     let positionValue = 0;
     for (var asset of Exchange.assets) {
       let markPrice =
-        useExecutionInfoPrice && executionInfo
+        useExecutionInfoPrice && executionInfo && executionInfo.asset == asset
           ? executionInfo.price
           : Exchange.getMarkPrice(asset);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1775,8 +1775,8 @@ export const checkLiquidity = (
   // We default to min lot size to still show a price
   const fillSize = size || constants.MIN_LOT_SIZE;
 
-  slippage ||= constants.PERP_MARKET_ORDER_SPOT_SLIPPAGE;
-  orderbook ||= Exchange.getOrderbook(asset);
+  slippage ??= constants.PERP_MARKET_ORDER_SPOT_SLIPPAGE;
+  orderbook ??= Exchange.getOrderbook(asset);
 
   const orderbookSide =
     side === types.Side.ASK ? orderbook.bids : orderbook.asks;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1769,10 +1769,14 @@ export const checkLiquidity = (
   size: number,
   asset: Asset,
   side: types.Side,
-  orderbook: types.DepthOrderbook
+  slippage?: number,
+  orderbook?: types.DepthOrderbook
 ): types.LiquidityCheckInfo => {
   // We default to min lot size to still show a price
   const fillSize = size || constants.MIN_LOT_SIZE;
+
+  slippage ||= constants.PERP_MARKET_ORDER_SPOT_SLIPPAGE;
+  orderbook ||= Exchange.getOrderbook(asset);
 
   const orderbookSide =
     side === types.Side.ASK ? orderbook.bids : orderbook.asks;
@@ -1795,7 +1799,8 @@ export const checkLiquidity = (
       orderbookLevel.price,
       side,
       asset,
-      orderbook
+      orderbook,
+      slippage
     );
 
     if (!isWithinSlippge) {
@@ -1826,7 +1831,8 @@ const checkWithinSlippageTolerance = (
   price: number,
   side: types.Side,
   asset: Asset,
-  orderbook: types.DepthOrderbook
+  orderbook: types.DepthOrderbook,
+  slippage: number
 ): boolean => {
   const spotPrice = Exchange.getMarkPrice(asset);
 
@@ -1839,7 +1845,7 @@ const checkWithinSlippageTolerance = (
   if (side === types.Side.BID && price < markPrice) return true;
   if (side === types.Side.ASK && price > markPrice) return true;
 
-  const maxSlippage = constants.PERP_MARKET_ORDER_SPOT_SLIPPAGE * markPrice;
+  const maxSlippage = slippage * markPrice;
 
   return Math.abs(price - markPrice) <= Math.abs(maxSlippage);
 };


### PR DESCRIPTION
- Fix getMaxTradeSize() to correctly use uPnL
- Add optional `useExecutionInfoPrice` to `getLeverage`, allowing an override of the mark price