### PR TITLE
Fix anchor.bn truncation, improve invalid asset behaviour and improve market refresh robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Version changes are pinned to SDK releases.
 
 - Fix anchor.BN truncation in risk calcs. ([#307](https://github.com/zetamarkets/sdk/pull/307))
 - Replace throw with an undefined return for invalid assets. ([#307](https://github.com/zetamarkets/sdk/pull/307))
-- Add check for Exchange.isInitialized when refreshing serum markets. ([#307](https://github.com/zetamarkets/sdk/pull/307))
+- Add check for Exchange.isInitialized when refreshing markets. ([#307](https://github.com/zetamarkets/sdk/pull/307))
 
 ## [1.13.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.13.3]
+
+- Fix anchor.BN truncation in risk calcs. ([#307](https://github.com/zetamarkets/sdk/pull/307))
+- Replace throw with an undefined return for invalid assets. ([#307](https://github.com/zetamarkets/sdk/pull/307))
+- Add check for Exchange.isInitialized when refreshing serum markets. ([#307](https://github.com/zetamarkets/sdk/pull/307))
+
 ## [1.13.2]
 
 - Add pyth asset. ([#305](https://github.com/zetamarkets/sdk/pull/305))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -42,7 +42,7 @@ export function assetToName(asset: Asset): string | null {
   if (asset == Asset.PYTH) return "PYTH";
   if (asset == Asset.UNDEFINED) return "UNDEFINED";
   if (asset == null) return null; // Some things, like clock callbacks, are for all assets and return asset=null
-  throw Error("Invalid asset");
+  return undefined;
 }
 
 export function nameToAsset(name: string): Asset {
@@ -54,7 +54,7 @@ export function nameToAsset(name: string): Asset {
   if (name == "BNB") return Asset.BNB;
   if (name == "PYTH") return Asset.PYTH;
   if (name == "UNDEFINED") return Asset.UNDEFINED;
-  throw Error("Invalid asset");
+  return undefined;
 }
 
 export function getAssetMint(asset: Asset): PublicKey {
@@ -69,7 +69,7 @@ export function toProgramAsset(asset: Asset): any {
   if (asset == Asset.ARB) return { arb: {} };
   if (asset == Asset.BNB) return { bnb: {} };
   if (asset == Asset.PYTH) return { pyth: {} };
-  throw Error("Invalid asset");
+  return undefined;
 }
 
 export function fromProgramAsset(asset: any): Asset {
@@ -94,7 +94,7 @@ export function fromProgramAsset(asset: any): Asset {
   if (objectEquals(asset, { pyth: {} })) {
     return Asset.PYTH;
   }
-  throw Error("Invalid asset");
+  return undefined;
 }
 
 export function assetToIndex(asset: Asset): number {
@@ -121,7 +121,7 @@ export function assetToIndex(asset: Asset): number {
       return 6;
     }
   }
-  throw new Error("Invalid asset");
+  return undefined;
 }
 
 export function indexToAsset(index: number): Asset {
@@ -148,5 +148,5 @@ export function indexToAsset(index: number): Asset {
       return Asset.PYTH;
     }
   }
-  throw new Error("Invalid index");
+  return undefined;
 }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -40,9 +40,8 @@ export function assetToName(asset: Asset): string | null {
   if (asset == Asset.ARB) return "ARB";
   if (asset == Asset.BNB) return "BNB";
   if (asset == Asset.PYTH) return "PYTH";
-  if (asset == Asset.UNDEFINED) return "UNDEFINED";
   if (asset == null) return null; // Some things, like clock callbacks, are for all assets and return asset=null
-  return undefined;
+  return "UNDEFINED";
 }
 
 export function nameToAsset(name: string): Asset {
@@ -53,8 +52,7 @@ export function nameToAsset(name: string): Asset {
   if (name == "ARB") return Asset.ARB;
   if (name == "BNB") return Asset.BNB;
   if (name == "PYTH") return Asset.PYTH;
-  if (name == "UNDEFINED") return Asset.UNDEFINED;
-  return undefined;
+  return Asset.UNDEFINED;
 }
 
 export function getAssetMint(asset: Asset): PublicKey {
@@ -69,7 +67,7 @@ export function toProgramAsset(asset: Asset): any {
   if (asset == Asset.ARB) return { arb: {} };
   if (asset == Asset.BNB) return { bnb: {} };
   if (asset == Asset.PYTH) return { pyth: {} };
-  return undefined;
+  return { undefined: {} };
 }
 
 export function fromProgramAsset(asset: any): Asset {
@@ -94,7 +92,7 @@ export function fromProgramAsset(asset: any): Asset {
   if (objectEquals(asset, { pyth: {} })) {
     return Asset.PYTH;
   }
-  return undefined;
+  return Asset.UNDEFINED;
 }
 
 export function assetToIndex(asset: Asset): number {
@@ -121,7 +119,7 @@ export function assetToIndex(asset: Asset): number {
       return 6;
     }
   }
-  return undefined;
+  return 255; // Undefined is 255 onchain
 }
 
 export function indexToAsset(index: number): Asset {
@@ -148,5 +146,5 @@ export function indexToAsset(index: number): Asset {
       return Asset.PYTH;
     }
   }
-  return undefined;
+  return Asset.UNDEFINED;
 }

--- a/src/risk-utils.ts
+++ b/src/risk-utils.ts
@@ -181,8 +181,11 @@ export function addFakeTradeToAccount(
       let priceDiff = entryPrice.sub(
         new anchor.BN(convertDecimalToNativeInteger(price, 1))
       );
+
+      let sizeMul = side == types.Side.BID ? size : -1 * size;
+
       marginAccount.balance = marginAccount.balance.add(
-        new anchor.BN(side == types.Side.BID ? size : -size).mul(priceDiff)
+        new anchor.BN(sizeMul * priceDiff.toNumber())
       );
 
       editedPosition.costOfTrades = editedPosition.costOfTrades.sub(

--- a/src/subexchange.ts
+++ b/src/subexchange.ts
@@ -166,10 +166,6 @@ export class SubExchange {
    * Refreshes serum markets cache
    */
   public async updateSerumMarkets() {
-    if (!Exchange.isInitialized) {
-      return;
-    }
-
     console.info(
       `Refreshing Serum markets for ${assetToName(this._asset)} SubExchange.`
     );
@@ -185,7 +181,7 @@ export class SubExchange {
    * Checks only if the perp serum markets are stale and refreshes it if so
    */
   public async updatePerpSerumMarketIfNeeded(epochDelay: number) {
-    if (Exchange.isHalted(this._asset)) {
+    if (!Exchange.isInitialized || Exchange.isHalted(this._asset)) {
       return;
     }
 

--- a/src/subexchange.ts
+++ b/src/subexchange.ts
@@ -166,6 +166,10 @@ export class SubExchange {
    * Refreshes serum markets cache
    */
   public async updateSerumMarkets() {
+    if (!Exchange.isInitialized) {
+      return;
+    }
+
     console.info(
       `Refreshing Serum markets for ${assetToName(this._asset)} SubExchange.`
     );

--- a/src/subexchange.ts
+++ b/src/subexchange.ts
@@ -181,7 +181,11 @@ export class SubExchange {
    * Checks only if the perp serum markets are stale and refreshes it if so
    */
   public async updatePerpSerumMarketIfNeeded(epochDelay: number) {
-    if (!Exchange.isInitialized || Exchange.isHalted(this._asset)) {
+    if (!Exchange.isInitialized) {
+      return;
+    }
+
+    if (Exchange.isHalted(this._asset)) {
       return;
     }
 


### PR DESCRIPTION
A bundle of a few small fixes:
- Fix anchor.BN truncation in risk calcs: small accounts will truncate uPnL to 0, causing accuracy issues with trade size and liq price calcs
- Replace throw with an undefined return for invalid asset: throwing is a bit too aggressive, and caused some issues in FE
- Add check for Exchange.isInitialized when refreshing markets: if loading is super slow then the .isHalted() check can cause syntax errors because Exchange.state is undefined