### PR TITLE
Only burn tokens for openOrdersAccounts that have nonzero tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.13.4]
+
+- Filter nonzero open orders accounts before sending burn txs. ([#310](https://github.com/zetamarkets/sdk/pull/310))
+
 ## [1.13.3]
 
 - Add PYTH to devnet. ([#309](https://github.com/zetamarkets/sdk/pull/309))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Cranks struggled because they had to send hundreds of txs every time, mostly for empty accounts. Filter the accounts to only send txs we need, drastically reducing load (eg. thousands of accounts down to 50 for SOL)