### PR TITLE
Remove maxLeverage clamp in getMaxTradeSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.15.4]
+
+- Remove leverage clamp in getMaxTradeSize([#322](https://github.com/zetamarkets/sdk/pull/322))
+
 ## [1.15.3]
 
 - Override asset loading for devnet ([#320](https://github.com/zetamarkets/sdk/pull/320))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -840,6 +840,10 @@ export class RiskCalculator {
     bufferPercent: number = 5,
     maxIterations: number = 100
   ): number {
+    // Don't cap leverage if not a taker trade, because leverage only counts positions
+    if (maxLeverage <= 0 || !isTaker) {
+      maxLeverage = -1;
+    }
     if (thresholdPercent <= 0) {
       throw Error("thresholdPercent must be > 0");
     }

--- a/src/risk.ts
+++ b/src/risk.ts
@@ -840,21 +840,6 @@ export class RiskCalculator {
     bufferPercent: number = 5,
     maxIterations: number = 100
   ): number {
-    // Cap max leverage to 0 < maxLeverage < maxAssetLeverage
-    // Also don't cap leverage if not a taker trade, because leverage only counts positions
-    if (maxLeverage <= 0 || !isTaker) {
-      maxLeverage = -1;
-    }
-    if (maxLeverage != -1) {
-      let maxAssetLeverage =
-        100 /
-        convertNativeBNToDecimal(
-          Exchange.pricing.marginParameters[assets.assetToIndex(tradeAsset)]
-            .futureMarginInitial
-        );
-      maxLeverage = Math.min(maxLeverage, maxAssetLeverage);
-    }
-
     if (thresholdPercent <= 0) {
       throw Error("thresholdPercent must be > 0");
     }


### PR DESCRIPTION
Added as a safety, but it's actually wrong and causing bad slider behaviour on FE. It isn't really necessary so I'm just removing it.