### PR TITLE
Better prio fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Version changes are pinned to SDK releases.
 
 ## Unreleased
 
+## [1.16.5]
+
+- Better auto priority fees ([#326](https://github.com/zetamarkets/sdk/pull/326))
+
 ## [1.16.4]
 
 - Temporary override for margin reqs until backend deploys leverage drop ([#325](https://github.com/zetamarkets/sdk/pull/325))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.16.4-beta.2",
+  "version": "1.16.5",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -225,7 +225,8 @@ export const ASK_ORDERS_INDEX = 1;
 
 export const MAX_TOTAL_SPREAD_ACCOUNT_CONTRACTS = 100_000_000;
 
-export const DEFAULT_MICRO_LAMPORTS_PER_CU_FEE = 1000;
+export const DEFAULT_MICRO_LAMPORTS_PER_CU_FEE = 1_000;
+export const PRIO_FEE_UPPER_LIMIT = 1_000;
 
 export const STATIC_AND_PERPS_LUT: {
   devnet: AddressLookupTableAccount;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -226,7 +226,7 @@ export const ASK_ORDERS_INDEX = 1;
 export const MAX_TOTAL_SPREAD_ACCOUNT_CONTRACTS = 100_000_000;
 
 export const DEFAULT_MICRO_LAMPORTS_PER_CU_FEE = 1_000;
-export const PRIO_FEE_UPPER_LIMIT = 1_000;
+export const PRIO_FEE_UPPER_LIMIT = 100_000;
 
 export const STATIC_AND_PERPS_LUT: {
   devnet: AddressLookupTableAccount;

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -314,13 +314,13 @@ export class Exchange {
 
   private _autoPriorityFeeOffset: number = 0;
   private _autoPriorityFeeMultiplier: number = 1;
+  private _autoPriorityFeeUseMax: boolean = false;
 
   // Micro lamports per CU of fees.
   public get autoPriorityFeeUpperLimit(): number {
     return this._autoPriorityFeeUpperLimit;
   }
-  private _autoPriorityFeeUpperLimit: number =
-    constants.DEFAULT_MICRO_LAMPORTS_PER_CU_FEE;
+  private _autoPriorityFeeUpperLimit: number = constants.PRIO_FEE_UPPER_LIMIT;
 
   public get blockhashCommitment(): Commitment {
     return this._blockhashCommitment;
@@ -334,6 +334,10 @@ export class Exchange {
   public setAutoPriorityFeeScaling(offset: number = 0, multiplier: number = 1) {
     this._autoPriorityFeeMultiplier = multiplier;
     this._autoPriorityFeeOffset = offset;
+  }
+
+  public toggleAutoPriorityFeeUseMax() {
+    this._autoPriorityFeeUseMax = !this._autoPriorityFeeUseMax;
   }
 
   public updatePriorityFee(microLamportsPerCU: number) {
@@ -704,7 +708,8 @@ export class Exchange {
     return [...this._subExchanges.values()];
   }
 
-  private async updateAutoFee() {
+  // Public so you can call it as often as you want. By default gets called in the clock interval
+  public async updateAutoFee() {
     let accountList = [];
 
     // Query the most written-to accounts
@@ -729,11 +734,14 @@ export class Exchange {
         .slice(0, 20) // Grab the latest 20
         .map((obj) => obj.prioritizationFee); // Take a list of prioritizationFee values only
 
-      let median = utils.median(fees);
-      let medianScaled =
-        this._autoPriorityFeeOffset + median * this._autoPriorityFeeMultiplier;
+      let num = this._autoPriorityFeeUseMax
+        ? utils.max(fees)
+        : utils.median(fees);
+
+      let numScaled =
+        this._autoPriorityFeeOffset + num * this._autoPriorityFeeMultiplier;
       this._priorityFee = Math.round(
-        Math.min(medianScaled, this._autoPriorityFeeUpperLimit)
+        Math.min(numScaled, this._autoPriorityFeeUpperLimit)
       );
       console.log(
         `AutoUpdate priority fee. New fee = ${this._priorityFee} microlamports per compute unit`

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -735,7 +735,7 @@ export class Exchange {
         .map((obj) => obj.prioritizationFee); // Take a list of prioritizationFee values only
 
       let num = this._autoPriorityFeeUseMax
-        ? utils.max(fees)
+        ? Math.max(...fees)
         : utils.median(fees);
 
       let numScaled =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1843,17 +1843,6 @@ export function median(arr: number[]): number | undefined {
   return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
 }
 
-export function max(arr: number[]): number | undefined {
-  if (!arr.length) return undefined;
-  let max = arr[0];
-  for (var a of arr) {
-    if (a > max) {
-      max = a;
-    }
-  }
-  return max;
-}
-
 export const checkLiquidity = (
   size: number,
   asset: Asset,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1843,6 +1843,17 @@ export function median(arr: number[]): number | undefined {
   return s.length % 2 === 0 ? (s[mid - 1] + s[mid]) / 2 : s[mid];
 }
 
+export function max(arr: number[]): number | undefined {
+  if (!arr.length) return undefined;
+  let max = arr[0];
+  for (var a of arr) {
+    if (a > max) {
+      max = a;
+    }
+  }
+  return max;
+}
+
 export const checkLiquidity = (
   size: number,
   asset: Asset,


### PR DESCRIPTION
Improve auto prio fees:
- Change calc to use max instead of median (toggleable)
- Significantly increase default upper limit

Example fees:
<img width="740" alt="image" src="https://github.com/zetamarkets/sdk/assets/103913117/f7e21a34-fd35-40f0-8df0-7818279b09e0">
