### PR TITLE
Remove throw if no open orders account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 Version changes are pinned to SDK releases.
 
+## [1.20.2]
+
+- Relax throwing if no open orders account is detected in some client functions. ([#349](https://github.com/zetamarkets/sdk/pull/349))
+
 ## [1.20.1]
 
 - Improve tx confirmations by polling. ([#347](https://github.com/zetamarkets/sdk/pull/347))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
We're throwing too freely, instead just log a warning and use the utils pubkey which will be created later anyway