### PR TITLE
Trim trailing \0s on referral IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 Version changes are pinned to SDK releases.
 
+## [1.27.4]
+
+- Trim trailing \0s on referral IDs ([#388](https://github.com/zetamarkets/sdk/pull/388))
+
 ## [1.26.4]
 
 - Respect Exchange.skipRpcConfirmation everywhere. ([#384](https://github.com/zetamarkets/sdk/pull/384))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -495,7 +495,7 @@ export function getReferrerIdAccount(
   return anchor.web3.PublicKey.findProgramAddressSync(
     [
       Buffer.from(anchor.utils.bytes.utf8.encode("referrer-id-account")),
-      Buffer.from(id),
+      Buffer.from(id.replace(/[\0]+$/g, "")),
     ],
     programId
   );


### PR DESCRIPTION
Fixes issue when changing referral ID when you already have one that's <6 chars