### PR TITLE
Fix withdrawonly enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 Version changes are pinned to SDK releases.
 
+## [1.39.0]
+
+- Change enum u8 for withdraw_only account type. ([#409](https://github.com/zetamarkets/sdk/pull/409))
+
 ## [1.38.0]
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,7 +44,7 @@ export enum MarginAccountType {
   NORMAL_T7 = 18,
   NORMAL_T8 = 19,
   NORMAL_T9 = 20,
-  WITHDRAW_ONLY = 100,
+  WITHDRAW_ONLY = 21,
 }
 
 export const ZETA_PID: {


### PR DESCRIPTION
anchor deserialisation assumes that enums are in order, so this breaks :( 