### PR TITLE
fix 'Invalid account discriminator' error when close account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Version changes are pinned to SDK releases.
 
 ## [1.44.0]
 
-- fix 'Invalid account discriminator' error when close account. ([#416](https://github.com/zetamarkets/sdk/pull/416))
+- Fix 'Invalid account discriminator' error when closing account. ([#416](https://github.com/zetamarkets/sdk/pull/416))
 
 ## [1.43.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 Version changes are pinned to SDK releases.
 
+## [1.44.0]
+
+- fix 'Invalid account discriminator' error when close account. ([#416](https://github.com/zetamarkets/sdk/pull/416))
+
 ## [1.43.0]
 
 - New asset GMC. ([#415](https://github.com/zetamarkets/sdk/pull/415))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zetamarkets/sdk",
   "repository": "https://github.com/zetamarkets/sdk/",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "description": "Zeta SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cross-client.ts
+++ b/src/cross-client.ts
@@ -354,27 +354,31 @@ export class CrossClient {
     client._accountSubscriptionId = connection.onAccountChange(
       client._accountAddress,
       async (accountInfo: AccountInfo<Buffer>, context: Context) => {
-        client._account = Exchange.program.coder.accounts.decode(
-          types.ProgramAccountType.CrossMarginAccount,
-          accountInfo.data
-        );
-
-        if (throttle || client._updatingState) {
-          client._pendingUpdate = true;
-          client._pendingUpdateSlot = context.slot;
-          return;
+        try {
+          client._account = Exchange.program.coder.accounts.decode(
+            types.ProgramAccountType.CrossMarginAccount,
+            accountInfo.data
+          );
+  
+          if (throttle || client._updatingState) {
+            client._pendingUpdate = true;
+            client._pendingUpdateSlot = context.slot;
+            return;
+          }
+  
+          await client.updateState(false);
+          client._lastUpdateTimestamp = Exchange.clockTimestamp;
+  
+          if (callback !== undefined) {
+            callback(null, EventType.USER, context.slot, {
+              UserCallbackType: types.UserCallbackType.CROSSMARGINACCOUNTCHANGE,
+            });
+          }
+  
+          client.updateOpenOrdersAddresses();
+        } catch (e) {
+          console.log(`CrossMarginAccount subscription failed. Error: ${e}`);
         }
-
-        await client.updateState(false);
-        client._lastUpdateTimestamp = Exchange.clockTimestamp;
-
-        if (callback !== undefined) {
-          callback(null, EventType.USER, context.slot, {
-            UserCallbackType: types.UserCallbackType.CROSSMARGINACCOUNTCHANGE,
-          });
-        }
-
-        client.updateOpenOrdersAddresses();
       },
       connection.commitment
     );
@@ -382,15 +386,19 @@ export class CrossClient {
     client._accountManagerSubscriptionId = connection.onAccountChange(
       client._accountManagerAddress,
       async (accountInfo: AccountInfo<Buffer>, context: Context) => {
-        client._accountManager = Exchange.program.coder.accounts.decode(
-          types.ProgramAccountType.CrossMarginAccountManager,
-          accountInfo.data
-        );
-
-        if (callback !== undefined) {
-          callback(null, EventType.USER, context.slot, {
-            UserCallbackType: types.UserCallbackType.CROSSMARGINACCOUNTCHANGE,
-          });
+        try {
+          client._accountManager = Exchange.program.coder.accounts.decode(
+            types.ProgramAccountType.CrossMarginAccountManager,
+            accountInfo.data
+          );
+  
+          if (callback !== undefined) {
+            callback(null, EventType.USER, context.slot, {
+              UserCallbackType: types.UserCallbackType.CROSSMARGINACCOUNTCHANGE,
+            });
+          }
+        } catch (e) {
+          console.log(`CrossMarginAccountManager subscription failed. Error: ${e}`);
         }
       },
       connection.commitment


### PR DESCRIPTION
add the try and catch to ignore Error: Invalid account discriminator when closing the cross margin account and account manager.